### PR TITLE
Add Python Indent plugin to x86 and x64

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -487,7 +487,7 @@
 			"folder-name": "Python Indent",
 			"display-name": "Python Indent",
 			"version": "1.0.0.1",
-			"id": "93917d8eba433854d7d30f2def49959023a3d4ede31755048b6dba5838f2edcd",
+			"id": "d5774b7b9acff231119a90e90557d341d25e519f248a68cd1ae688a6114a211d",
 			"repository": "https://bitbucket.org/Kered13/python-indent-for-notepad/downloads/Python%20Indent%20x64.zip",
 			"description": "Python auto-indent plugin.",
 			"author": "Derek Brown",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -484,6 +484,16 @@
 			"homepage": "https://github.com/npp-plugins/pork2sausage"
 		},
 		{
+			"folder-name": "Python Indent",
+			"display-name": "Python Indent",
+			"version": "1.0.0.1",
+			"id": "0ac14c25d9132f99dc55da86f9098a8a8979f805424f0f368f1a4736b581bc4f",
+			"repository": "https://bitbucket.org/Kered13/python-indent-for-notepad/downloads/Python%20Indent%20x64.zip",
+			"description": "Python auto-indent plugin.",
+			"author": "Derek Brown",
+			"homepage": "https://bitbucket.org/Kered13/python-indent-for-notepad"
+		},
+		{
 			"folder-name": "NppSaveAsAdmin",
 			"display-name": "Save as admin",
 			"version": "1.0.172",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -487,7 +487,7 @@
 			"folder-name": "Python Indent",
 			"display-name": "Python Indent",
 			"version": "1.0.0.1",
-			"id": "0ac14c25d9132f99dc55da86f9098a8a8979f805424f0f368f1a4736b581bc4f",
+			"id": "93917d8eba433854d7d30f2def49959023a3d4ede31755048b6dba5838f2edcd",
 			"repository": "https://bitbucket.org/Kered13/python-indent-for-notepad/downloads/Python%20Indent%20x64.zip",
 			"description": "Python auto-indent plugin.",
 			"author": "Derek Brown",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -487,7 +487,7 @@
 			"folder-name": "Python Indent",
 			"display-name": "Python Indent",
 			"version": "1.0.0.1",
-			"id": "170e145689299587c97937e841bf9ca588062e9435666a96e341903e92e1b06c",
+			"id": "d0b0079e1486aa9a6b39bef32bb7eef78c13ec17af755a8ea04a3c3bd956b090",
 			"repository": "https://bitbucket.org/Kered13/python-indent-for-notepad/downloads/Python%20Indent%20x64.zip",
 			"description": "Python auto-indent plugin.",
 			"author": "Derek Brown",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -487,7 +487,7 @@
 			"folder-name": "Python Indent",
 			"display-name": "Python Indent",
 			"version": "1.0.0.1",
-			"id": "d5774b7b9acff231119a90e90557d341d25e519f248a68cd1ae688a6114a211d",
+			"id": "170e145689299587c97937e841bf9ca588062e9435666a96e341903e92e1b06c",
 			"repository": "https://bitbucket.org/Kered13/python-indent-for-notepad/downloads/Python%20Indent%20x64.zip",
 			"description": "Python auto-indent plugin.",
 			"author": "Derek Brown",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -807,7 +807,7 @@
 			"folder-name": "Python Indent",
 			"display-name": "Python Indent",
 			"version": "1.0.0.1",
-			"id": "5d6cda90bb920a1f5e9f54fe0f8f2b50b04ee8945d2250065353316f75457269",
+			"id": "1b26acb5a6d143b98e698e99d7fbde32492f3d5b936ab58d8ddcefd2af884374",
 			"repository": "https://bitbucket.org/Kered13/python-indent-for-notepad/downloads/Python%20Indent.zip",
 			"description": "Python auto-indent plugin.",
 			"author": "Derek Brown",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -807,7 +807,7 @@
 			"folder-name": "Python Indent",
 			"display-name": "Python Indent",
 			"version": "1.0.0.1",
-			"id": "5fe5b8f301dff688775ef5a61209c77a85f890d394594ab966052a1bdd31ab3c",
+			"id": "8353109ba2f445bdc2ee0ab8072b4b0df4290b2398a8acbaac30fb3168750947",
 			"repository": "https://bitbucket.org/Kered13/python-indent-for-notepad/downloads/Python%20Indent.zip",
 			"description": "Python auto-indent plugin.",
 			"author": "Derek Brown",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -807,7 +807,7 @@
 			"folder-name": "Python Indent",
 			"display-name": "Python Indent",
 			"version": "1.0.0.1",
-			"id": "8353109ba2f445bdc2ee0ab8072b4b0df4290b2398a8acbaac30fb3168750947",
+			"id": "4f5a05321d0994f42e65cc9e1d6fe11c036a963fb3e10a92f737d39530023c7b",
 			"repository": "https://bitbucket.org/Kered13/python-indent-for-notepad/downloads/Python%20Indent.zip",
 			"description": "Python auto-indent plugin.",
 			"author": "Derek Brown",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -804,6 +804,16 @@
 			"homepage": "http://mpcabd.igeex.biz/notepad-plugin-to-run-python-scripts/"
 		},
 		{
+			"folder-name": "Python Indent",
+			"display-name": "Python Indent",
+			"version": "1.0.0.1",
+			"id": "5fe5b8f301dff688775ef5a61209c77a85f890d394594ab966052a1bdd31ab3c",
+			"repository": "https://bitbucket.org/Kered13/python-indent-for-notepad/downloads/Python%20Indent.zip",
+			"description": "Python auto-indent plugin.",
+			"author": "Derek Brown",
+			"homepage": "https://bitbucket.org/Kered13/python-indent-for-notepad"
+		},
+		{
 			"folder-name": "NppQCP",
 			"display-name": "Quick Color Picker +",
 			"version": "2.0",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -807,7 +807,7 @@
 			"folder-name": "Python Indent",
 			"display-name": "Python Indent",
 			"version": "1.0.0.1",
-			"id": "4f5a05321d0994f42e65cc9e1d6fe11c036a963fb3e10a92f737d39530023c7b",
+			"id": "5d6cda90bb920a1f5e9f54fe0f8f2b50b04ee8945d2250065353316f75457269",
 			"repository": "https://bitbucket.org/Kered13/python-indent-for-notepad/downloads/Python%20Indent.zip",
 			"description": "Python auto-indent plugin.",
 			"author": "Derek Brown",


### PR DESCRIPTION
This plugin used to be in the repository (migrated from the old plugin manager), but it was an old version that I hadn't maintained for years and didn't even have a version correctly set.

A few months back I started working on it again (mostly just polishing up the code), and this time I have properly set the version. This is my new release.