### PR TITLE
Add VisualStudioLineCopy to plugins.

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -614,6 +614,16 @@
 			"homepage": ""
 		},
 		{
+			"folder-name": "VisualStudioLineCopy",
+			"display-name": "Visual Studio Line Copy",
+			"version": "1.0.0.1",
+			"id": "215b517858412b642c28686673c5ddc71a7a3a78bfa1669482992ed761b667aa",
+			"repository": "https://bitbucket.org/Kered13/notepad-visualstudiolinecopy/downloads/VisualStudioLineCopy%20x64.zip",
+			"description": "Adds two commands to Notepad++ CopyAllowLine and CutAllowLine, which adds Visual Studio style copy/cutting to Notepad++.",
+			"author": "Mackenzie Zastrow (forked by Derek Brown)",
+			"homepage": "https://bitbucket.org/Kered13/notepad-visualstudiolinecopy"
+		},
+		{
 			"folder-name": "XMLTools",
 			"display-name": "XML Tools",
 			"version": "2.4.11.0",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1034,6 +1034,16 @@
 			"homepage": "https://sourceforge.net/projects/npptranslate/"
 		},
 		{
+			"folder-name": "VisualStudioLineCopy",
+			"display-name": "Visual Studio Line Copy",
+			"version": "1.0.0.1",
+			"id": "65bb55f0b3e209ef9262fdb26a28606ecc6a3f8fb1878b827d190d9da7859287",
+			"repository": "https://bitbucket.org/Kered13/notepad-visualstudiolinecopy/downloads/VisualStudioLineCopy.zip",
+			"description": "Adds two commands to Notepad++ CopyAllowLine and CutAllowLine, which adds Visual Studio style copy/cutting to Notepad++.",
+			"author": "Mackenzie Zastrow (forked by Derek Brown)",
+			"homepage": "https://bitbucket.org/Kered13/notepad-visualstudiolinecopy"
+		},
+		{
 			"folder-name": "WakaTime",
 			"display-name": "WakaTime",
 			"version": "4.0.2",


### PR DESCRIPTION
This plugin was previously removed because it did not contain version information. The plugin is unmaintained by it's original author, so I have forked it and added version information, as well as adding 64-bit support.