### PR TITLE
Release of v0.4.0 of NppEditorConfig

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -144,6 +144,16 @@
 			"homepage": "https://github.com/Predelnik/DSpellCheck"
 		},
 		{
+			"folder-name": "NppEditorConfig",
+			"display-name": "EditorConfig",
+			"version": "0.4.0",
+			"id": "ae43152e91d8310ab28859992d3661aba24d8d69a64b93cd12b2f531a1038f56",
+			"repository": "https://github.com/editorconfig/editorconfig-notepad-plus-plus/releases/download/v0.4.0/NppEditorConfig-040-x64.zip",
+			"description": "EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readibly and they work nicely with version control systems.",
+			"author": "EditorConfig Team",
+			"homepage": "https://github.com/editorconfig/editorconfig-notepad-plus-plus"
+		},
+		{
 			"folder-name": "ElasticTabstops",
 			"display-name": "ElasticTabstops",
 			"version": "1.3",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -216,12 +216,12 @@
 		{
 			"folder-name": "NppEditorConfig",
 			"display-name": "EditorConfig",
-			"version": "0.3.1",
-			"id": "d9f1d6391b323567f36b61055534c4fb24f84b02fc9c13cb1ce0f29b46787f43",
-			"repository": "https://downloads.sourceforge.net/project/editorconfig/EditorConfig-Notepad%2B%2B-Plugin/0.3.1/Unicode/NppEditorConfig.zip",
+			"version": "0.4.0",
+			"id": "d5e76e32dd8a06c4b9e3c2c057ca0849cee466c2e608c0ad04907f68698db850",
+			"repository": "https://github.com/editorconfig/editorconfig-notepad-plus-plus/releases/download/v0.4.0/NppEditorConfig-040-x86.zip",
 			"description": "EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readibly and they work nicely with version control systems.",
-			"author": "Hong Xu",
-			"homepage": "https://github.com/editorconfig/editorconfig-notepad-plus-plus#readme"
+			"author": "EditorConfig Team",
+			"homepage": "https://github.com/editorconfig/editorconfig-notepad-plus-plus"
 		},
 		{
 			"folder-name": "ElasticTabstops",


### PR DESCRIPTION
The EditorConfig plugin v0.4.0 has been released.
This PR updates the x86 entry and adds a x64 entry.