### PR TITLE
+ added new plugin NppMarkdownPanel

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -454,6 +454,16 @@
 			"homepage": "https://github.com/viper3400/RegExTractor/wiki/de_userdocumentation"
 		},
 		{
+			"folder-name": "NppMarkdownPanel",
+			"display-name": "Markdown Panel",
+			"version": "0.3.0",
+			"id": "8473aa2f610e483a42397be292b78887363b1c53e89042d4def2580925e9ac21",
+			"repository": "https://github.com/mohzy83/NppMarkdownPanel/releases/download/0.3.0/NppMarkdownPanel-0.3.0.0-x64.zip",
+			"description": "Lightweight Notepad++ plugin to preview Markdown files with good default style",
+			"author": "Mohzy83",
+			"homepage": "https://github.com/mohzy83/NppMarkdownPanel"
+		},
+		{
 			"folder-name": "PluginManager",
 			"display-name": "Plugin Manager",
 			"version": "1.4.12",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -754,6 +754,16 @@
 			"homepage": "https://github.com/viper3400/RegExTractor/wiki/de_userdocumentation"
 		},
 		{
+			"folder-name": "NppMarkdownPanel",
+			"display-name": "Markdown Panel",
+			"version": "0.3.0",
+			"id": "dc496d34ae312b2a0b2e593101938b99fc94afe75ecbbb612c410a4e862f5434",
+			"repository": "https://github.com/mohzy83/NppMarkdownPanel/releases/download/0.3.0/NppMarkdownPanel-0.3.0.0-x86.zip",
+			"description": "Lightweight Notepad++ plugin to preview Markdown files with good default style",
+			"author": "Mohzy83",
+			"homepage": "https://github.com/mohzy83/NppMarkdownPanel"
+		},
+		{
 			"folder-name": "ccc",
 			"display-name": "PHP Autocompletion",
 			"version": "1.4.1",


### PR DESCRIPTION
NppMarkdownPanel is a lightweight plugin for Notepad++ to preview markdown files with a good default style (github style)