### PR TITLE
Add PreviewHTML, version 1.3.2.0, both 32 and 64 bits.

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -524,6 +524,16 @@
 			"homepage": "https://github.com/npp-plugins/pork2sausage"
 		},
 		{
+			"folder-name": "PreviewHTML",
+			"display-name": "Preview HTML",
+			"version": "1.3.2.0",
+			"id": "127dbdd677b5f3f75661f06e67e4e2b35cb5e926863b6268a51c11e72a08f8ec",
+			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML64.zip?name=&uuid=v1.3.2.0-64",
+			"description": "Preview HTML files inside Notepad++ (or in a floating window) without having to save them first.",
+			"author": "Martijn Coppoolse",
+			"homepage": "https://fossil.2of4.net/npp_preview"
+		},
+		{
 			"folder-name": "Python Indent",
 			"display-name": "Python Indent",
 			"version": "1.0.0.1",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -814,6 +814,16 @@
 			"homepage": "https://github.com/npp-plugins/pork2sausage"
 		},
 		{
+			"folder-name": "PreviewHTML",
+			"display-name": "Preview HTML",
+			"version": "1.3.2.0",
+			"id": "b7538d5b4c61e7232ad6befe3a5eb1799544a4de741d4acd896716e9273f260b",
+			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML32.zip?name=&uuid=v1.3.2.0-32",
+			"description": "Preview HTML files inside Notepad++ (or in a floating window) without having to save them first.",
+			"author": "Martijn Coppoolse",
+			"homepage": "https://fossil.2of4.net/npp_preview"
+		},
+		{
 			"folder-name": "PyNPP",
 			"display-name": "PyNPP",
 			"version": "1.2",


### PR DESCRIPTION
The plugin has been tested by me and [several other people](https://notepad-plus-plus.org/community/topic/17303/preview-plugin/39), and subsequently announced [here](https://notepad-plus-plus.org/community/topic/17320/preview-html-version-1-3-2-0-both-32-bits-and-64-bits).