### PR TITLE
 Updated URLs for PreviewHTML plugin, and tested them.

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -426,9 +426,9 @@
 		{
 			"folder-name": "NppFTP",
 			"display-name": "NppFTP",
-			"version": "0.27.5",
-			"id": "a5c2d60b4269c9a8f3e167cce90844da641b5e74e62609ad2391055ca9f09631",
-			"repository": "https://github.com/ashkulz/NppFTP/releases/download/v0.27.5/NppFTP-x64_N759.zip",
+			"version": "0.28.3",
+			"id": "147ceab402952a5ebfc2f27efb7b820a1485b9eabf5e3f3901067e038387329c",
+			"repository": "https://github.com/ashkulz/NppFTP/releases/download/v0.28.3/NppFTP-x64.zip",
 			"description": "NppFTP: a plugin that allows FTP, FTPS, FTPES and SFTP communications. Very useful for web development.",
 			"author": "ashish_kulz",
 			"homepage": "https://ashkulz.github.io/NppFTP/"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -524,6 +524,16 @@
 			"homepage": "https://github.com/npp-plugins/pork2sausage"
 		},
 		{
+			"folder-name": "PreviewHTML",
+			"display-name": "Preview HTML",
+			"version": "1.3.2.0",
+			"id": "127dbdd677b5f3f75661f06e67e4e2b35cb5e926863b6268a51c11e72a08f8ec",
+			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML64.zip?name=&uuid=v1.3.2.0-64",
+			"description": "Preview HTML files inside Notepad++ (or in a floating window) without having to save them first.",
+			"author": "Martijn Coppoolse",
+			"homepage": "https://fossil.2of4.net/npp_preview"
+		},
+		{
 			"folder-name": "Python Indent",
 			"display-name": "Python Indent",
 			"version": "1.0.0.1",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -528,7 +528,7 @@
 			"display-name": "Preview HTML",
 			"version": "1.3.2.0",
 			"id": "127dbdd677b5f3f75661f06e67e4e2b35cb5e926863b6268a51c11e72a08f8ec",
-			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML64.zip?name=&uuid=v1.3.2.0-64",
+			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML64.zip%3Fname%3D%26uuid%3Dv1.3.2.0-64",
 			"description": "Preview HTML files inside Notepad++ (or in a floating window) without having to save them first.",
 			"author": "Martijn Coppoolse",
 			"homepage": "https://fossil.2of4.net/npp_preview"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -696,9 +696,9 @@
 		{
 			"folder-name": "NppFTP",
 			"display-name": "NppFTP",
-			"version": "0.27.5",
-			"id": "33ce9ebc17c95816f210c122868076291586410ad8e965823e4839da88be9134",
-			"repository": "https://github.com/ashkulz/NppFTP/releases/download/v0.27.5/NppFTP-x86_N759.zip",
+			"version": "0.28.3",
+			"id": "e37bd5b3eec2924c39955ffd945fd084bba507bc0620df3d42e411504af95a16",
+			"repository": "https://github.com/ashkulz/NppFTP/releases/download/v0.28.3/NppFTP-x86.zip",
 			"description": "NppFTP: a plugin that allows FTP, FTPS, FTPES and SFTP communications. Very useful for web development.",
 			"author": "ashish_kulz",
 			"homepage": "https://ashkulz.github.io/NppFTP/"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -814,6 +814,16 @@
 			"homepage": "https://github.com/npp-plugins/pork2sausage"
 		},
 		{
+			"folder-name": "PreviewHTML",
+			"display-name": "Preview HTML",
+			"version": "1.3.2.0",
+			"id": "b7538d5b4c61e7232ad6befe3a5eb1799544a4de741d4acd896716e9273f260b",
+			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML32.zip?name=&uuid=v1.3.2.0-32",
+			"description": "Preview HTML files inside Notepad++ (or in a floating window) without having to save them first.",
+			"author": "Martijn Coppoolse",
+			"homepage": "https://fossil.2of4.net/npp_preview"
+		},
+		{
 			"folder-name": "PyNPP",
 			"display-name": "PyNPP",
 			"version": "1.2",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -828,7 +828,7 @@
 			"display-name": "Preview HTML",
 			"version": "1.3.2.0",
 			"id": "b7538d5b4c61e7232ad6befe3a5eb1799544a4de741d4acd896716e9273f260b",
-			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML32.zip?name=&uuid=v1.3.2.0-32",
+			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML32.zip%3Fname%3D%26uuid%3Dv1.3.2.0-32",
 			"description": "Preview HTML files inside Notepad++ (or in a floating window) without having to save them first.",
 			"author": "Martijn Coppoolse",
 			"homepage": "https://fossil.2of4.net/npp_preview"


### PR DESCRIPTION
Even the query string separators need to be URI-encoded for some reason, otherwise the updater doesn't download the file.