### PR TITLE
fix release date for code alignment plugin. It don't come from the future

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -100,7 +100,7 @@
 			"description": "Code alignment helps you present your code beautifully, enhancing clarity and readability.\n\nAlign your code by any character. Fast logical shortcuts to perform common alignments such as equals and period.",
 			"author": "Chris McGrath",
 			"homepage": "https://github.com/cpmcgrath/codealignment",
-			"release-date": "2019-12-16"
+			"release-date": "2018-12-16"
 		},
 		{
 			"folder-name": "CodeStats",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -144,7 +144,7 @@
 			"description": "Code alignment helps you present your code beautifully, enhancing clarity and readability.\n\nAlign your code by any character. Fast logical shortcuts to perform common alignments such as equals and period.",
 			"author": "Chris McGrath",
 			"homepage": "https://github.com/cpmcgrath/codealignment",
-			"release-date": "2019-12-16"
+			"release-date": "2018-12-16"
 		},
 		{
 			"folder-name": "CodeStats",


### PR DESCRIPTION
release-date: 2019-12-16 fixed to 2018-12-16