### PR TITLE
Updated SHA2 for new version which contains a fix for Windows 10 NPP x64

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -297,7 +297,7 @@
 			"folder-name": "Linefilter3",
 			"display-name": "Linefilter3",
 			"version": "1.0.0.0",
-			"id": "3ab06753831e729ecc6be1f316fe2a86256f65ccbdf56b4da082c47aef2d548a",
+			"id": "ecf5800b8e48e0dbcc84bbe494e515ab481a22b79b5ac596bdb2b8995baef5ed",
 			"repository": "https://www.seelisoft.net/Linefilter3/Linefilter3_x64.zip",
 			"description": "A plugin for Notepad++ that allows you to filter for a given text and display the matching lines in a new NPP window.",
 			"author": "SeeliSoft",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -284,6 +284,16 @@
 			"homepage": "https://sites.google.com/site/fstellari/nppplugins"
 		},
 		{
+			"folder-name": "Linefilter3",
+			"display-name": "Linefilter3",
+			"version": "1.0.0.0",
+			"id": "3ab06753831e729ecc6be1f316fe2a86256f65ccbdf56b4da082c47aef2d548a",
+			"repository": "https://www.seelisoft.net/Linefilter3/Linefilter3_x64.zip",
+			"description": "A plugin for Notepad++ that allows you to filter for a given text and display the matching lines in a new NPP window.",
+			"author": "SeeliSoft",
+			"homepage": "https://www.seelisoft.net/Linefilter3/"
+		},
+		{
 			"folder-name": "Linter",
 			"display-name": "Linter",
 			"version": "0.1.0.0",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -514,6 +514,16 @@
 			"homepage": "http://www.scout-soft.com/linefilter"
 		},
 		{
+			"folder-name": "Linefilter3",
+			"display-name": "Linefilter3",
+			"version": "1.0.0.0",
+			"id": "c3d6c69ce840b4a2b3bb0cbdf4d12338f38b2bbd83fb61e1f01eeaedcd9b11ff",
+			"repository": "https://www.seelisoft.net/Linefilter3/Linefilter3_x86.zip",
+			"description": "A plugin for Notepad++ that allows you to filter for a given text and display the matching lines in a new NPP window.",
+			"author": "SeeliSoft",
+			"homepage": "https://www.seelisoft.net/Linefilter3/"
+		},
+		{
 			"folder-name": "Linter",
 			"display-name": "Linter",
 			"version": "0.1.0.0",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -527,7 +527,7 @@
 			"folder-name": "Linefilter3",
 			"display-name": "Linefilter3",
 			"version": "1.0.0.0",
-			"id": "c3d6c69ce840b4a2b3bb0cbdf4d12338f38b2bbd83fb61e1f01eeaedcd9b11ff",
+			"id": "7adbed33c702c57dffa40aab356d7f549fc5b7d2852cfd9b05c3681b041dc0ea",
 			"repository": "https://www.seelisoft.net/Linefilter3/Linefilter3_x86.zip",
 			"description": "A plugin for Notepad++ that allows you to filter for a given text and display the matching lines in a new NPP window.",
 			"author": "SeeliSoft",


### PR DESCRIPTION
Previous release of my linefilter had an issue with NPP x64 on Windows 10. I found a more recent .NET template and reworked everything. Now it successfully loads, so I need to update the SHA2 hash.