### PR TITLE
Update GedcomLexer for x86 and new GedcomLexer for x64

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -224,6 +224,16 @@
 			"homepage": "https://sourceforge.net/projects/extsettings"
 		},
 		{
+			"folder-name": "GedcomLexer",
+			"display-name": "GEDCOM Lexer",
+			"version": "0.4.0.140",
+			"id": "d1c492beccc3531efebd3c98a4e3159380283b6b84e55812979861a3d791c6ab",
+			"repository": "https://sourceforge.net/projects/gedcomlexer/files/GedcomLexer-0.4.0-r140/GedcomLexer-0.4.0-r140-x64.zip",
+			"description": "View and edit GEDCOM files with syntax highlighting of: level, xref id, tag, pointer, value and escape tokens. Customize coloration and font styles. Grammar errors are also highlighted. View GEDCOM files in outline mode by folding sections based on line level.",
+			"author": "Stan Mitchell",
+			"homepage": "https://sourceforge.net/projects/gedcomlexer/"
+		},
+		{
 			"folder-name": "HTMLTag",
 			"display-name": "HTML Tag",
 			"version": "1.1.0.0",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -344,14 +344,14 @@
 			"homepage": "https://sourceforge.net/projects/fingertext/"
 		},
 		{
-			"folder-name": "gedcomlexer",
+			"folder-name": "GedcomLexer",
 			"display-name": "GEDCOM Lexer",
-			"version": "0.3.3.100",
-			"id": "b2b148879b88cab3f967e7678a66d009481b91abf5a02aa29324ce2821ee2561",
-			"repository": "https://sourceforge.net/projects/gedcomlexer/files/GedcomLexer-0.3.3-r100/GedcomLexer-0.3.3-r100.zip",
-			"description": "View &amp; edit GEDCOM files with syntax highlighting of: level, xref id, tag, pointer, value and escape tokens. Customize coloration and font styles. Grammar errors are also highlighted. View GEDCOM files in outline mode by folding sections based on line level.",
+			"version": "0.4.0.140",
+			"id": "16c38bd8b57ac63508be9ee78f9d94d865a6df0dc17932d91381df840bd1ad94",
+			"repository": "https://sourceforge.net/projects/gedcomlexer/files/GedcomLexer-0.4.0-r140/GedcomLexer-0.4.0-r140-x86.zip",
+			"description": "View and edit GEDCOM files with syntax highlighting of: level, xref id, tag, pointer, value and escape tokens. Customize coloration and font styles. Grammar errors are also highlighted. View GEDCOM files in outline mode by folding sections based on line level.",
 			"author": "Stan Mitchell",
-			"homepage": "http://www.genapps.net"
+			"homepage": "https://sourceforge.net/projects/gedcomlexer/"
 		},
 		{
 			"folder-name": "GmodLua",


### PR DESCRIPTION
Updated GedcomLexer 0.4.0-r140:

- Support for x86 and x64
- Fixed extremely slow loading of GEDCOM files since Notepad++ version 7.7, when the Scintilla component was upgraded from version 3.56 to version 4.14. This upgrade prompted a rewrite of GedcomLexer's core lexer utilizing functions from Scintilla's StyleContext class.
- Since plugin manager does not install the external lexer configuration file with the plugin, GedcomLexer now detects a missing configuration file, and displays a message box with instructions to repair the situation.