### PR TITLE
XMLTools 3.0.0.3

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1006,10 +1006,10 @@
 		{
 			"folder-name": "XMLTools",
 			"display-name": "XML Tools",
-			"version": "2.4.11.0",
-			"id": "9c1de52b873b633646a6ea32df9209d652652361ba5c2b8cbb90f91438bca2bd",
-			"repository": "https://github.com/morbac/xmltools/releases/download/2.4.11.0/Xml.Tools.2.4.11.0.x64.Unicode.zip",
-			"description": "Small set of useful tools for editing XML. Plugin is libXML2-based. The features are:\r\n- XML syntax Check\r\n- XML Schema (XSD) + DTD Validation\r\n- XML tag autoclose\r\n- Pretty print\n- Linarize XML\r\n- Current XML Path\r\n- Conversion XML &amp;lt;-&amp;gt; Text\n- Comment / Uncomment\r\n- XPath expression evaluation",
+			"version": "3.0.0.3",
+			"id": "61299fd38a7612282cfde294c5b5fbd93655ba12278c47692078f8af3f89eeb8",
+			"repository": "https://github.com/morbac/xmltools/releases/download/3.0.0.3/XMLTools-3.0.0.3-x64.zip",
+			"description": "Small set of useful tools for editing XML. Plugin is MSXML-based. The features are:\r\n- XML syntax Check\r\n- XML Schema (XSD) + DTD Validation\r\n- XML tag autoclose\r\n- Pretty print\n- Linarize XML\r\n- Current XML Path\r\n- Conversion XML &amp;lt;-&amp;gt; Text\n- Comment / Uncomment\r\n- XPath expression evaluation",
 			"author": "Nicolas Crittin",
 			"homepage": "https://github.com/morbac/xmltools"
 		},

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1416,10 +1416,10 @@
 		{
 			"folder-name": "XMLTools",
 			"display-name": "XML Tools",
-			"version": "2.4.11.0",
-			"id": "a189a565b1ed222727d960e35bef067376302009223da90742a3b98274173440",
-			"repository": "https://github.com/morbac/xmltools/releases/download/2.4.11.0/Xml.Tools.2.4.11.0.x86.Unicode.zip",
-			"description": "Small set of useful tools for editing XML. Plugin is libXML2-based. The features are:\r\n- XML syntax Check\r\n- XML Schema (XSD) + DTD Validation\r\n- XML tag autoclose\r\n- Pretty print\n- Linarize XML\r\n- Current XML Path\r\n- Conversion XML &amp;lt;-&amp;gt; Text\n- Comment / Uncomment\r\n- XPath expression evaluation",
+			"version": "3.0.0.3",
+			"id": "61411bec596da187ab7ba81c2fb6f426c0d9b21e7e414118cd5b4be022773643",
+			"repository": "https://github.com/morbac/xmltools/releases/download/3.0.0.3/XMLTools-3.0.0.3-x86.zip",
+			"description": "Small set of useful tools for editing XML. Plugin is MSXML-based. The features are:\r\n- XML syntax Check\r\n- XML Schema (XSD) + DTD Validation\r\n- XML tag autoclose\r\n- Pretty print\n- Linarize XML\r\n- Current XML Path\r\n- Conversion XML &amp;lt;-&amp;gt; Text\n- Comment / Uncomment\r\n- XPath expression evaluation",
 			"author": "Nicolas Crittin",
 			"homepage": "https://github.com/morbac/xmltools"
 		},


### PR DESCRIPTION
Files have been re-uploaded to fix whitespace replacement. This was due to github "upload files" function which obviously replace tabs