### PR TITLE
Adding links to list files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **Notepad++ Plugin List** is an official collection of Notepad++ plugins. It helps built-in Plugin Admin in Notepad++ to install/update/remove the plugins as users desire.
 
-The list is in json format, but encapsulated in a binary (DLL), so it can be signed by a certificate to avoid being hacked. Any Notepad++ plugin is welcome to be submit here, but please test it locally before doing your PR. Here are all the informations you need for doing tests locally:
+The list is in json format, but encapsulated in a binary (DLL), so it can be signed by a certificate to avoid being hacked. Any Notepad++ plugin is welcome to be submit here, but please test it locally before doing your PR. To review the current list of plugins and their features see the generated list of Plugindescriptions in either [64-Bit Plugin List](doc/plugin_list_x64.md) or [32-Bit Plugin List](doc/plugin_list_x32.md).
+
+Here are all the informations you need for doing tests locally:
 https://npp-user-manual.org/docs/plugins/#plugins-admin
 
 Please check here if you need any support:


### PR DESCRIPTION
Link from NPP page refers to front page.
Hence readers would need to see the lists linked at front page.
