### PR TITLE
RegexTrainer

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1062,6 +1062,16 @@
 			"description": "Tired of zooming your document everytime you just want to scroll but accidentally still holding the [Ctrl] key? Then this is what you want! It disables mouse zoom, keyboard zoom, or both.",
 			"author": "Stanislav Eckert",
 			"homepage": "https://github.com/StanDog/npp-zoomdisabler"
+		},
+		{
+		  "folder-name": "RegexTrainer",
+		  "display-name": "Regex Trainer",
+		  "version": "1.0.0",
+		  "id": "9b1c3302e1bfc7dcd51d4df3915e4d9acbab7a94455b3ac5021da93394b4e91a",
+		  "repository": "https://github.com/ahmoylaw/RegexTrainer-Descriptions/raw/master/Release-x64/RegexTrainer.zip",
+		  "description": "Regex Trainer (based on net framework 4) that supports a complex regular expression.",
+		  "author": "Ahmoy Law",
+		  "homepage": "https://github.com/ahmoylaw/RegexTrainer-Descriptions"
 		}
 	]
 }

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1492,6 +1492,16 @@
 			"description": "Tired of zooming your document everytime you just want to scroll but accidentally still holding the [Ctrl] key? Then this is what you want! It disables mouse zoom, keyboard zoom, or both.",
 			"author": "Stanislav Eckert",
 			"homepage": "https://github.com/StanDog/npp-zoomdisabler"
+		},
+		{
+		  "folder-name": "RegexTrainer",
+		  "display-name": "Regex Trainer",
+		  "version": "1.0.0",
+		  "id": "2ae9b1115414da77379fafec2dc11277200dab6b73b55dc9636bb30a9d5f6503",
+		  "repository": "https://github.com/ahmoylaw/RegexTrainer-Descriptions/raw/master/Release/RegexTrainer.zip",
+		  "description": "Regex Trainer (based on net framework 4) that supports a complex regular expression.",
+		  "author": "Ahmoy Law",
+		  "homepage": "https://github.com/ahmoylaw/RegexTrainer-Descriptions"
 		}
 	]
 }


### PR DESCRIPTION
Add RegexTrainer plugin for both x64 and x86.  This RegexTrainer plugin is created using c# net framework 4 and supports for a complex expression.