### PR TITLE
Update Compare2 plugin to v2.0.1

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -156,9 +156,9 @@
 		{
 			"folder-name": "ComparePlugin",
 			"display-name": "Compare",
-			"version": "2.0.0",
-			"id": "c0f37cc70695cdd595432f7ec1c3b7e3e2fb509d96bd1da20e3ecea387c99f4f",
-			"repository": "https://github.com/pnedev/compare-plugin/releases/download/v2.0.0_npp7.7/ComparePlugin_v2.0.0_npp7.7_X64.zip",
+			"version": "2.0.1",
+			"id": "77dedf98ea2280528d726c0053db2001e90da7588e14ee01a98933f121bb15cb",
+			"repository": "https://github.com/pnedev/compare-plugin/releases/download/v2.0.1/ComparePlugin_v2.0.1_X64.zip",
 			"description": "Shows the differences between 2 files (side by side).",
 			"author": "Ty Landercasper, Jean-Sebastien Leroy, Pavel Nedev",
 			"homepage": "https://github.com/jsleroy/compare-plugin"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -196,9 +196,9 @@
 		{
 			"folder-name": "ComparePlugin",
 			"display-name": "Compare",
-			"version": "2.0.0",
-			"id": "cf69a8436f01bee252ce29c42b019d9c135ad78496085dfc7b21b126cc79981d",
-			"repository": "https://github.com/pnedev/compare-plugin/releases/download/v2.0.0_npp7.7/ComparePlugin_v2.0.0_npp7.7_x86.zip",
+			"version": "2.0.1",
+			"id": "07972c1c7e3012a46ac6ef133a6500ca851bddc9c83471df2f118519a0241ed5",
+			"repository": "https://github.com/pnedev/compare-plugin/releases/download/v2.0.1/ComparePlugin_v2.0.1_x86.zip",
 			"description": "Shows the differences between 2 files (side by side).",
 			"author": "Ty Landercasper, Jean-Sebastien Leroy, Pavel Nedev",
 			"homepage": "https://github.com/jsleroy/compare-plugin"


### PR DESCRIPTION
v2.0.1 is the same as v2.0.0 but for plugins API of Notepad++ 7.7 and above
and will hopefully eliminate the confusion the users have when updating Notepad++
from older versions and when addressing Compare2 variants.