### PR TITLE
RestApiToText v1.2

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -896,9 +896,9 @@
 		{
 			"folder-name": "RestApiToText",
 			"display-name": "RestApiToText",
-			"version": "1.1",
-			"id": "1be5fded5d17eafd244c000aeeb9526d94daa17825dc14dbb6d64bffee4d334e",
-			"repository": "https://github.com/eljefe7000/RestApiToText/raw/master/x64/Release/v1.1/RestApiToText.zip",
+			"version": "1.2",
+			"id": "3ee603a8df8de295fcf170746070b16a284228cee1009d930f88e98c7db259af",
+			"repository": "https://github.com/eljefe7000/RestApiToText/raw/master/x64/Release/v1.2/RestApiToText.zip",
 			"description": "Make REST API calls using content from an editor tab, then see the results in a new tab.\r\nUseful when you want to test a REST API or store the results of a REST call, without the need for an external REST tool.",
 			"author": "Jeffrey Smith",
 			"homepage": "https://github.com/eljefe7000/RestApiToText"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1206,9 +1206,9 @@
 		{
 			"folder-name": "RestApiToText",
 			"display-name": "RestApiToText",
-			"version": "1.1",
-			"id": "ad424d570742af4c252c003ad763f9827e8d7bdf449880034c1136e3809a7097",
-			"repository": "https://github.com/eljefe7000/RestApiToText/raw/master/Release/v1.1/RestApiToText.zip",
+			"version": "1.2",
+			"id": "8d46671df62abc28997813ea1ac741503f31e1d7c49b7e08d93502964e68fa95",
+			"repository": "https://github.com/eljefe7000/RestApiToText/raw/master/Release/v1.2/RestApiToText.zip",
 			"description": "Make REST API calls using content from an editor tab, then see the results in a new tab.\r\nUseful when you want to test a REST API or store the results of a REST call, without the need for an external REST tool.",
 			"author": "Jeffrey Smith",
 			"homepage": "https://github.com/eljefe7000/RestApiToText"


### PR DESCRIPTION
RestApiToText v1.2:
1. Added JSON pretty-printing for responses with a Content-Type response header containing "application/json".
2. Added support for the HEAD and OPTIONS verbs.
3. URLs with no verb now default to a GET.