### PR TITLE
Update Papyrus Script Lexer plugin to v0.1.1.13 for both 64bit and 32bit

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -796,9 +796,9 @@
 		{
 			"folder-name": "Papyrus",
 			"display-name": "Papyrus Script Lexer",
-			"version": "0.1.0.8",
-			"id": "fa8998dcfaa038d909d7a4a40287259b7485ab3304b731aa9e329dbc20f7b464",
-			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.1.0/PapyrusPlugin-v0.1.0-x64.zip",
+			"version": "0.1.1.13",
+			"id": "4c16921773fec886cbeb6fce8c7b75a9f129e469da7cf223ba068883cafd476e",
+			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.1.1/PapyrusPlugin-v0.1.1-x64.zip",
 			"description": "View and edit Papyrus Script files used by Bethesda games with syntax highlighting, function and block folding, hyperlinks to referenced scripts, plus compilation support with anonymized output and error list view.",
 			"author": "blu3mania",
 			"homepage": "https://github.com/blu3mania/npp-papyrus"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -794,6 +794,16 @@
 			"homepage": "https://github.com/francostellari/NppPlugins"
 		},
 		{
+			"folder-name": "Papyrus",
+			"display-name": "Papyrus Script Lexer",
+			"version": "0.1.0.8",
+			"id": "fa8998dcfaa038d909d7a4a40287259b7485ab3304b731aa9e329dbc20f7b464",
+			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.1.0/PapyrusPlugin-v0.1.0-x64.zip",
+			"description": "View and edit Papyrus Script files used by Bethesda games with syntax highlighting, function and block folding, hyperlinks to referenced scripts, plus compilation support with anonymized output and error list view.",
+			"author": "blu3mania",
+			"homepage": "https://github.com/blu3mania/npp-papyrus"
+		},
+		{
 			"folder-name": "PoorMansTSqlFormatterNppPlugin",
 			"display-name": "Poor Man's T-Sql Formatter",
 			"version": "1.6.13.31508",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1044,6 +1044,16 @@
 			"homepage": "https://github.com/StanDog/npp-phpautocompletion"
 		},
 		{
+			"folder-name": "Papyrus",
+			"display-name": "Papyrus Script Lexer",
+			"version": "0.1.0.8",
+			"id": "5daf23763d672a0d837489fc64b2448ece10e95b7c244a047375118a20b8dd1e",
+			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.1.0/PapyrusPlugin-v0.1.0-x86.zip",
+			"description": "View and edit Papyrus Script files used by Bethesda games with syntax highlighting, function and block folding, hyperlinks to referenced scripts, plus compilation support with anonymized output and error list view.",
+			"author": "blu3mania",
+			"homepage": "https://github.com/blu3mania/npp-papyrus"
+		},
+		{
 			"folder-name": "PoorMansTSqlFormatterNppPlugin",
 			"display-name": "Poor Man's T-Sql Formatter",
 			"version": "1.6.13.31502",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1046,9 +1046,9 @@
 		{
 			"folder-name": "Papyrus",
 			"display-name": "Papyrus Script Lexer",
-			"version": "0.1.0.8",
-			"id": "5daf23763d672a0d837489fc64b2448ece10e95b7c244a047375118a20b8dd1e",
-			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.1.0/PapyrusPlugin-v0.1.0-x86.zip",
+			"version": "0.1.1.13",
+			"id": "22ab72b90d88cbe5a673ac274ffe966ec641428b0001718cf525c4cb4b7fea2c",
+			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.1.1/PapyrusPlugin-v0.1.1-x86.zip",
 			"description": "View and edit Papyrus Script files used by Bethesda games with syntax highlighting, function and block folding, hyperlinks to referenced scripts, plus compilation support with anonymized output and error list view.",
 			"author": "blu3mania",
 			"homepage": "https://github.com/blu3mania/npp-papyrus"


### PR DESCRIPTION
Release output are generated with GitHub action: https://github.com/blu3mania/npp-papyrus/blob/main/.github/workflows/release.yml
VirusTotal scan results linked on release page: https://github.com/blu3mania/npp-papyrus/releases

Latest CodeQL scan: https://github.com/blu3mania/npp-papyrus/actions/runs/686714943
