### PR TITLE
FWDataViz v1.0.3.0 & GotoLineCol 1.2.0.1 updates (x86 & x64)

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -288,7 +288,7 @@
 			"display-name": "Fixed-width Data Visualizer",
 			"version": "1.0.3.0",
 			"id": "e3af56541762341fa2da05cc8b9e38b64de770ab4564d2415880ba990be24ec1",
-			"repository": "https://github.com/shriprem/FWDataViz/releases/download/1.0.2.0/FWDataViz_x64.zip",
+			"repository": "https://github.com/shriprem/FWDataViz/releases/download/1.0.3.0/FWDataViz_x64.zip",
 			"description": "Fixed Width Data Visualizer adds Excel-like features for fixed-width data files in Notepad++. Displays cursor position data. Jump to specific fields. Builtin dialogs to configure file-type, record-type & fields; and themes & colors. Automatic File Type Detection. Handles homogenous, mixed & multi-line records.",
 			"author": "Shridhar Kumar",
 			"homepage": "https://github.com/shriprem/FWDataViz"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -286,8 +286,8 @@
 		{
 			"folder-name": "FWDataViz",
 			"display-name": "Fixed-width Data Visualizer",
-			"version": "1.0.2.0",
-			"id": "7447757f0106ecbad960d7ac3f0a48902b8d6fa3488dfc211f7a803f180eced2",
+			"version": "1.0.3.0",
+			"id": "e3af56541762341fa2da05cc8b9e38b64de770ab4564d2415880ba990be24ec1",
 			"repository": "https://github.com/shriprem/FWDataViz/releases/download/1.0.2.0/FWDataViz_x64.zip",
 			"description": "Fixed Width Data Visualizer adds Excel-like features for fixed-width data files in Notepad++. Displays cursor position data. Jump to specific fields. Builtin dialogs to configure file-type, record-type & fields; and themes & colors. Automatic File Type Detection. Handles homogenous, mixed & multi-line records.",
 			"author": "Shridhar Kumar",
@@ -316,9 +316,9 @@
 		{
 			"folder-name": "GotoLineCol",
 			"display-name": "GotoLineCol",
-			"version": "1.2.0.0",
-			"id": "d52e4d786397f1ca096a99be4c9cbbfc12001c432e939535c51f3413fc77abd2",
-			"repository": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin/releases/download/1.2.0.0/GotoLineCol_x64.zip",
+			"version": "1.2.0.1",
+			"id": "2f6da6ff22122934fa47e3f2a6fa9cab42773509e4eef926030e351117476194",
+			"repository": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin/releases/download/1.2.0.1/GotoLineCol_x64.zip",
 			"description": "A plugin to navigate to a specified line and (byte-based or character-based) column position. Will also display character byte code, UTF-8 byte sequence & Unicode code point at cursor position.",
 			"author": "Shridhar Kumar",
 			"homepage": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -396,9 +396,9 @@
 		{
 			"folder-name": "FWDataViz",
 			"display-name": "Fixed-width Data Visualizer",
-			"version": "1.0.2.0",
-			"id": "5fdef151203ea579306d727520eb84cbc7ce1dd91b9002b9a09ddda43eefcab5",
-			"repository": "https://github.com/shriprem/FWDataViz/releases/download/1.0.2.0/FWDataViz_x86.zip",
+			"version": "1.0.3.0",
+			"id": "5a972aeeb93a28a96ad04136c083c41fba345ae8edac925a5691a21d0e6292de",
+			"repository": "https://github.com/shriprem/FWDataViz/releases/download/1.0.3.0/FWDataViz_x86.zip",
 			"description": "Fixed Width Data Visualizer adds Excel-like features for fixed-width data files in Notepad++. Displays cursor position data. Jump to specific fields. Builtin dialogs to configure file-type, record-type & fields; and themes & colors. Automatic File Type Detection. Handles homogenous, mixed & multi-line records.",
 			"author": "Shridhar Kumar",
 			"homepage": "https://github.com/shriprem/FWDataViz"
@@ -446,9 +446,9 @@
 		{
 			"folder-name": "GotoLineCol",
 			"display-name": "GotoLineCol",
-			"version": "1.2.0.0",
-			"id": "bfd6b159f279edd8c222657205d1ab6a7acada486b3aeb351bb780e4de350997",
-			"repository": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin/releases/download/1.2.0.0/GotoLineCol_x86.zip",
+			"version": "1.2.0.1",
+			"id": "748c03bb840401ebbdd9e0df247035ebffd17689aff1fe55d3705804a2cb712c",
+			"repository": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin/releases/download/1.2.0.1/GotoLineCol_x86.zip",
 			"description": "A plugin to navigate to a specified line and (byte-based or character-based) column position. Will also display character byte code, UTF-8 byte sequence & Unicode code point at cursor position.",
 			"author": "Shridhar Kumar",
 			"homepage": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin"


### PR DESCRIPTION
* FWDataViz 1.0.3.0 release adds [Record Type Themes](https://github.com/shriprem/FWDataViz/blob/master/docs/file_type_extract_dialog.md) feature
* GotoLineCol 1.2.0.1 minor update to fix the balloon tip text for the toolbar icon