### PR TITLE
Update Papyrus Script Lexer plugin to v0.2.1.18 for both x64 and x86

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -806,9 +806,9 @@
 		{
 			"folder-name": "Papyrus",
 			"display-name": "Papyrus Script Lexer",
-			"version": "0.2.0.16",
-			"id": "7b74732e4b39e92d7c7970875780204876d81ca31230c66f047f22956813c82a",
-			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.2.0/PapyrusPlugin-v0.2.0-x64.zip",
+			"version": "0.2.1.18",
+			"id": "5c836008601b2c6a614864960a1f3c6d91e313b3240ff23c6cf7b1dbf3bdeb83",
+			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.2.1/PapyrusPlugin-v0.2.1-x64.zip",
 			"description": "View and edit Papyrus Script files used by Bethesda games with syntax highlighting, function and block folding, hyperlinks to referenced scripts, keywords matching, plus compilation support with anonymized output and error list view.",
 			"author": "blu3mania",
 			"homepage": "https://github.com/blu3mania/npp-papyrus"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1056,9 +1056,9 @@
 		{
 			"folder-name": "Papyrus",
 			"display-name": "Papyrus Script Lexer",
-			"version": "0.2.0.16",
-			"id": "0354a2cef66cdaaba7541775dd308b8a23c834110d7460e190a4a25d6ec084e9",
-			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.2.0/PapyrusPlugin-v0.2.0-x86.zip",
+			"version": "0.2.1.18",
+			"id": "4534b0080f90abf35aa901ae7df6f44ad2dbd4f597070c16ef41793212f02818",
+			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.2.1/PapyrusPlugin-v0.2.1-x86.zip",
 			"description": "View and edit Papyrus Script files used by Bethesda games with syntax highlighting, function and block folding, hyperlinks to referenced scripts, keywords matching, plus compilation support with anonymized output and error list view.",
 			"author": "blu3mania",
 			"homepage": "https://github.com/blu3mania/npp-papyrus"


### PR DESCRIPTION
Release page with VirusTotal scan results: https://github.com/blu3mania/npp-papyrus/releases

Latest CodeQL scan: https://github.com/blu3mania/npp-papyrus/actions/runs/760094277