### PR TITLE
Rest api to text version 1.3.1.0

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -896,9 +896,9 @@
 		{
 			"folder-name": "RestApiToText",
 			"display-name": "RestApiToText",
-			"version": "1.3.0.0",
-			"id": "193d0b5455d7c63baa51a09b814fc555436f67f60969b5309b962308d29caa69",
-			"repository": "https://github.com/eljefe7000/RestApiToText/raw/master/x64/Release/v1.3.0.0/RestApiToText.zip",
+			"version": "1.3.1.0",
+			"id": "f8f2d1e5793b6f07af86abe629db12385067743c8366a33f527ece2489c1dff2",
+			"repository": "https://github.com/eljefe7000/RestApiToText/raw/master/x64/Release/v1.3.1.0/RestApiToText.zip",
 			"description": "Make REST API calls using content from an editor tab, then see the results in a new tab.\r\nUseful when you want to test a REST API or store the results of a REST call, without the need for an external REST tool.",
 			"author": "Jeffrey Smith",
 			"homepage": "https://github.com/eljefe7000/RestApiToText"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -896,9 +896,9 @@
 		{
 			"folder-name": "RestApiToText",
 			"display-name": "RestApiToText",
-			"version": "1.2.1.0",
-			"id": "62a9d38f9f82606b322faedcf8db45a6a12d64e85f89f6ee1d1c32eeb2ea91dd",
-			"repository": "https://github.com/eljefe7000/RestApiToText/raw/master/x64/Release/v1.2.1/RestApiToText.zip",
+			"version": "1.3.0.0",
+			"id": "193d0b5455d7c63baa51a09b814fc555436f67f60969b5309b962308d29caa69",
+			"repository": "https://github.com/eljefe7000/RestApiToText/raw/master/x64/Release/v1.3.0.0/RestApiToText.zip",
 			"description": "Make REST API calls using content from an editor tab, then see the results in a new tab.\r\nUseful when you want to test a REST API or store the results of a REST call, without the need for an external REST tool.",
 			"author": "Jeffrey Smith",
 			"homepage": "https://github.com/eljefe7000/RestApiToText"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1186,9 +1186,9 @@
 		{
 			"folder-name": "RestApiToText",
 			"display-name": "RestApiToText",
-			"version": "1.2.1.0",
-			"id": "6691d27a9c030007337bb3849dde58148be2aaf6165ac6019c7361b3f3dcadfe",
-			"repository": "https://github.com/eljefe7000/RestApiToText/raw/master/Release/v1.2.1/RestApiToText.zip",
+			"version": "1.3.0.0",
+			"id": "264a062832a533bcdd9f47c2e40ced9eb66dc9ca42a2450d9718457757d927f6",
+			"repository": "https://github.com/eljefe7000/RestApiToText/raw/master/Release/v1.3.0.0/RestApiToText.zip",
 			"description": "Make REST API calls using content from an editor tab, then see the results in a new tab.\r\nUseful when you want to test a REST API or store the results of a REST call, without the need for an external REST tool.",
 			"author": "Jeffrey Smith",
 			"homepage": "https://github.com/eljefe7000/RestApiToText"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1186,9 +1186,9 @@
 		{
 			"folder-name": "RestApiToText",
 			"display-name": "RestApiToText",
-			"version": "1.3.0.0",
-			"id": "264a062832a533bcdd9f47c2e40ced9eb66dc9ca42a2450d9718457757d927f6",
-			"repository": "https://github.com/eljefe7000/RestApiToText/raw/master/Release/v1.3.0.0/RestApiToText.zip",
+			"version": "1.3.1.0",
+			"id": "725a49d61b1323485b475ce8b03ccaa8335cb004f55b2463f6b0e3a084a5286d",
+			"repository": "https://github.com/eljefe7000/RestApiToText/raw/master/Release/v1.3.1.0/RestApiToText.zip",
 			"description": "Make REST API calls using content from an editor tab, then see the results in a new tab.\r\nUseful when you want to test a REST API or store the results of a REST call, without the need for an external REST tool.",
 			"author": "Jeffrey Smith",
 			"homepage": "https://github.com/eljefe7000/RestApiToText"


### PR DESCRIPTION
RestApiToText v1.3.1.0.  Added ability to use environment variables to hide private API keys.