### PR TITLE
Update pl.x64.json

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -646,9 +646,9 @@
 		{
 			"folder-name": "NppExport",
 			"display-name": "NppExport",
-			"version": "0.2.9.0",
+			"version": "0.3.0",
 			"id": "642748ac233f07328d3412cff437bdc4e030cb39f2ba01b4a3dec2f957012dab",
-			"repository": "https://github.com/chcg/NPP_ExportPlugin/releases/download/0.2.9.21/NppExport_0.2.9.21_x64.zip",
+			"repository": "https://github.com/chcg/NPP_ExportPlugin/releases/download/0.3.0/NppExport_0.3.0_x64.zip",
 			"description": "True WYSIWYG exporter. Allows you not only to save your source code as an HTML/RTF file, but also to copy your source code in the clipboard in RTF/HTML format, so you can paste it into your word processor (Openoffice.org Writer, LibreOffice Writer, Abiword, MS Word) to get the same visual effect.",
 			"author": "",
 			"homepage": "https://github.com/chcg/NPP_ExportPlugin"


### PR DESCRIPTION
Update NppExport from version 0.2.9.0 to 0.3.0. See https://github.com/chcg/NPP_ExportPlugin/releases.