### PR TITLE
Upgrade TakeNotes plugin to v1.22

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1096,9 +1096,9 @@
 		{
 			"folder-name": "TakeNotes",
 			"display-name": "TakeNotes",
-			"version": "1.2.1.0",
-			"id": "7988bbde2882185883a14e5aea9645f1b09c52fb2859830326c5fdb0d73b8dd3",
-			"repository": "https://github.com/francostellari/NppPlugins/raw/main/TakeNotes/TakeNotes_dll_1v21_x64.zip",
+			"version": "1.2.2.0",
+			"id": "402f28cf0432493789e6e959086eaa8ef724e76212f22c7d02a4c77ef7fc71de",
+			"repository": "https://github.com/francostellari/NppPlugins/raw/main/TakeNotes/TakeNotes_dll_1v22_x64.zip",
 			"description": "Helps people who like to use Notepad++ for jotting quick notes. Instead of using unnamed 'new ?' files, this plugins allows to quickly create new empty files in a folder of choice. The file names may be custom generated using a mask and may contain details such as the user name, date, and time of creation so that unique files may be generated. Additionally, the plugin allows to load exiting notes in the folder of choice, save existing files as a note, and open the last saved note quickly. Please refer to the Options dialog box for more details. It is strongly recommended to use this plugin in combination with AutoSave to make sure that you never loose a note.",
 			"author": "Franco Stellari",
 			"homepage": "https://github.com/francostellari/NppPlugins"


### PR DESCRIPTION
Fix a NPP crash due to a buffer overrun