### PR TITLE
2.0.0.0 Releases for FWDataViz & GotoLineCol with Darkmode-enabled plugin UI

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -6,20 +6,20 @@
 		{
 			"folder-name": "FWDataViz",
 			"display-name": "Fixed-width Data Visualizer",
-			"version": "1.4.2.1",
-			"id": "a8189c424e7d591d154023d83b653b29a6745d8b70393dbacd0b361c93dfcf0c",
-			"repository": "https://github.com/shriprem/FWDataViz/releases/download/v1.4.2.1/FWDataViz_arm64.zip",
-			"description": "Fixed Width Data Visualizer adds Excel-like features for fixed-width data files in Notepad++. Displays cursor position data. Jump to specific fields. Data Extraction. Builtin dialogs to configure file-type, record-type & fields; and themes & colors. Automatic File Type Detection. Handles homogenous, mixed & multi-line records.",
+			"version": "v2.0.0.0",
+			"id": "1a7b038b8eefef0ad202bfd28d5bf84a2710bfc72c5dfde0a6cedad33651528f",
+			"repository": "https://github.com/shriprem/FWDataViz/releases/download/v2.0.0.0/FWDataViz_arm64.zip",
+			"description": "Fixed Width Data Visualizer adds Excel-like features for fixed-width data files in Notepad++. Displays cursor position data. Jump to specific fields. Data Extraction. Builtin dialogs to configure file-type, record-type & fields; and themes & colors. Automatic File Type Detection. Handles homogenous, mixed & multi-line records. Darkmode enabled.",
 			"author": "Shridhar Kumar",
 			"homepage": "https://github.com/shriprem/FWDataViz"
 		},
 		{
 			"folder-name": "GotoLineCol",
 			"display-name": "GotoLineCol",
-			"version": "1.2.0.2",
-			"id": "1a349869f212b095370779ea9b64bfecf8760391ff79dd12e50be79284d09db3",
-			"repository": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin/releases/download/1.2.0.2/GotoLineCol_arm64.zip",
-			"description": "A plugin to navigate to a specified line and (byte-based or character-based) column position. Will also display character byte code, UTF-8 byte sequence & Unicode code point at cursor position.",
+			"version": "v2.0.0.0",
+			"id": "eff2373e1da7bf58565471e1799916b02023a0eb905f35ec16337798038a618b",
+			"repository": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin/releases/download/v2.0.0.0/GotoLineCol_arm64.zip",
+			"description": "A plugin to navigate to a specified line and (byte-based or character-based) column position. Will also display character byte code, UTF-8 byte sequence & Unicode code point at cursor position. Darkmode enabled.",
 			"author": "Shridhar Kumar",
 			"homepage": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin"
 		},

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -286,10 +286,10 @@
 		{
 			"folder-name": "FWDataViz",
 			"display-name": "Fixed-width Data Visualizer",
-			"version": "1.4.2.1",
-			"id": "b5b48a5c71c1d51c01199927d60f4532e6b769f09a9d80eb8662fbb8acd69c46",
-			"repository": "https://github.com/shriprem/FWDataViz/releases/download/v1.4.2.1/FWDataViz_x64.zip",
-			"description": "Fixed Width Data Visualizer adds Excel-like features for fixed-width data files in Notepad++. Displays cursor position data. Jump to specific fields. Data Extraction. Builtin dialogs to configure file-type, record-type & fields; and themes & colors. Automatic File Type Detection. Handles homogenous, mixed & multi-line records.",
+			"version": "v2.0.0.0",
+			"id": "0e94414893748c7f113fdb089aabbb7fdbcb271a2342e2a49170155562feea92",
+			"repository": "https://github.com/shriprem/FWDataViz/releases/download/v2.0.0.0/FWDataViz_x64.zip",
+			"description": "Fixed Width Data Visualizer adds Excel-like features for fixed-width data files in Notepad++. Displays cursor position data. Jump to specific fields. Data Extraction. Builtin dialogs to configure file-type, record-type & fields; and themes & colors. Automatic File Type Detection. Handles homogenous, mixed & multi-line records. Darkmode enabled.",
 			"author": "Shridhar Kumar",
 			"homepage": "https://github.com/shriprem/FWDataViz"
 		},
@@ -316,10 +316,10 @@
 		{
 			"folder-name": "GotoLineCol",
 			"display-name": "GotoLineCol",
-			"version": "1.2.0.2",
-			"id": "f9192e7c555e1b7372b993a8784d9c7b8085a854c0cf141693fb67443f9e0f30",
-			"repository": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin/releases/download/1.2.0.2/GotoLineCol_x64.zip",
-			"description": "A plugin to navigate to a specified line and (byte-based or character-based) column position. Will also display character byte code, UTF-8 byte sequence & Unicode code point at cursor position.",
+			"version": "v2.0.0.0",
+			"id": "6f5a2650aa80bbfa59a1e8b15834067695a3860023b7f8fcdc10eea5ea700edc",
+			"repository": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin/releases/download/v2.0.0.0/GotoLineCol_x64.zip",
+			"description": "A plugin to navigate to a specified line and (byte-based or character-based) column position. Will also display character byte code, UTF-8 byte sequence & Unicode code point at cursor position. Darkmode enabled.",
 			"author": "Shridhar Kumar",
 			"homepage": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin"
 		},

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -396,10 +396,10 @@
 		{
 			"folder-name": "FWDataViz",
 			"display-name": "Fixed-width Data Visualizer",
-			"version": "1.4.2.1",
-			"id": "c9b82b17801649ed87e2eebc98f5cf98fa2cc249d8164972ec845b0dfb4722f1",
-			"repository": "https://github.com/shriprem/FWDataViz/releases/download/v1.4.2.1/FWDataViz_x86.zip",
-			"description": "Fixed Width Data Visualizer adds Excel-like features for fixed-width data files in Notepad++. Displays cursor position data. Jump to specific fields. Data Extraction. Builtin dialogs to configure file-type, record-type & fields; and themes & colors. Automatic File Type Detection. Handles homogenous, mixed & multi-line records.",
+			"version": "v2.0.0.0",
+			"id": "aca8d51f8fb72d2c38ff6b359439e2246e79e6c5daa338e20f5b945aab7f47e9",
+			"repository": "https://github.com/shriprem/FWDataViz/releases/download/v2.0.0.0/FWDataViz_x86.zip",
+			"description": "Fixed Width Data Visualizer adds Excel-like features for fixed-width data files in Notepad++. Displays cursor position data. Jump to specific fields. Data Extraction. Builtin dialogs to configure file-type, record-type & fields; and themes & colors. Automatic File Type Detection. Handles homogenous, mixed & multi-line records. Darkmode enabled.",
 			"author": "Shridhar Kumar",
 			"homepage": "https://github.com/shriprem/FWDataViz"
 		},
@@ -446,10 +446,10 @@
 		{
 			"folder-name": "GotoLineCol",
 			"display-name": "GotoLineCol",
-			"version": "1.2.0.2",
-			"id": "9d2143383a7e56c08b05cedfdee46e2596ebdc2fc4de5b78f16f44ed3f3d4617",
-			"repository": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin/releases/download/1.2.0.2/GotoLineCol_x86.zip",
-			"description": "A plugin to navigate to a specified line and (byte-based or character-based) column position. Will also display character byte code, UTF-8 byte sequence & Unicode code point at cursor position.",
+			"version": "v2.0.0.0",
+			"id": "e04f2aa6bf2fd22048d10c74022aa3e648f1ff4cc891193300bb77e806f1baa5",
+			"repository": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin/releases/download/v2.0.0.0/GotoLineCol_x86.zip",
+			"description": "A plugin to navigate to a specified line and (byte-based or character-based) column position. Will also display character byte code, UTF-8 byte sequence & Unicode code point at cursor position. Darkmode enabled.",
 			"author": "Shridhar Kumar",
 			"homepage": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin"
 		},


### PR DESCRIPTION
1. [FWDataViz 2.0.0.0 Release](https://github.com/shriprem/FWDataViz/releases/tag/v2.0.0.0) with [darkmode-enabled plugin UI](https://github.com/shriprem/FWDataViz/blob/master/docs/dark_mode_ui.md)
2. [GotoLineCol 2.0.0.0 Release](https://github.com/shriprem/Goto-Line-Col-NPP-Plugin/releases/tag/v2.0.0.0) with [darkmode-enabled plugin UI](https://github.com/shriprem/Goto-Line-Col-NPP-Plugin/blob/master/DarkModeUI.md)