### PR TITLE
Update NppMenuSearch to 0.9.6

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -716,9 +716,9 @@
 		{
 			"folder-name": "NppMenuSearch",
 			"display-name": "NppMenuSearch",
-			"version": "0.9.3",
-			"id": "593736205bfe861e31e8435d179d9701599970a70db4ac5bde02dedc4c5ad9e8",
-			"repository": "https://sourceforge.net/projects/nppmenusearch/files/v0.9.3/NppMenuSearch_v0.9.3_x64.zip",
+			"version": "0.9.5",
+			"id": "7AA9C21BE13BB5E50117AF0930B21E34DA83F3152BFE4A518941FC387A1F194B",
+			"repository": "https://sourceforge.net/projects/nppmenusearch/files/v0.9.5/NppMenuSearch_v0.9.5_x64.zip",
 			"description": "Adds a text field to the toolbar for searching menu items and preference dialog options.",
 			"author": "Peter Frentrup",
 			"homepage": "https://github.com/peter-frentrup/NppMenuSearch"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -716,9 +716,9 @@
 		{
 			"folder-name": "NppMenuSearch",
 			"display-name": "NppMenuSearch",
-			"version": "0.9.5",
-			"id": "7AA9C21BE13BB5E50117AF0930B21E34DA83F3152BFE4A518941FC387A1F194B",
-			"repository": "https://sourceforge.net/projects/nppmenusearch/files/v0.9.5/NppMenuSearch_v0.9.5_x64.zip",
+			"version": "0.9.6",
+			"id": "7CA7BD5BB9D9FB6CB2CB54804F4BC7CC7C3E319D09ECBA761058C99E3ACC7870",
+			"repository": "https://sourceforge.net/projects/nppmenusearch/files/v0.9.6/NppMenuSearch_v0.9.6_x64.zip",
 			"description": "Adds a text field to the toolbar for searching menu items and preference dialog options.",
 			"author": "Peter Frentrup",
 			"homepage": "https://github.com/peter-frentrup/NppMenuSearch"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -946,9 +946,9 @@
 		{
 			"folder-name": "NppMenuSearch",
 			"display-name": "NppMenuSearch",
-			"version": "0.9.3",
-			"id": "8913738df45d24366790597df7ea26a6eb9ed5561d5a10b7adf9dcd17892219d",
-			"repository": "https://sourceforge.net/projects/nppmenusearch/files/v0.9.3/NppMenuSearch_v0.9.3_x86.zip",
+			"version": "0.9.5",
+			"id": "405A45274A6E27485AE28EA9B6CADC0F3E592E080B971171532968A506F6D1A9",
+			"repository": "https://sourceforge.net/projects/nppmenusearch/files/v0.9.5/NppMenuSearch_v0.9.5_x86.zip",
 			"description": "Adds a text field to the toolbar for searching menu items and preference dialog options.",
 			"author": "Peter Frentrup",
 			"homepage": "https://github.com/peter-frentrup/NppMenuSearch"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -946,9 +946,9 @@
 		{
 			"folder-name": "NppMenuSearch",
 			"display-name": "NppMenuSearch",
-			"version": "0.9.5",
-			"id": "405A45274A6E27485AE28EA9B6CADC0F3E592E080B971171532968A506F6D1A9",
-			"repository": "https://sourceforge.net/projects/nppmenusearch/files/v0.9.5/NppMenuSearch_v0.9.5_x86.zip",
+			"version": "0.9.6",
+			"id": "7FC4D9DE6A117795C90AA36DC288C13D1E1B679A5F8AB642B0220A7F69E211E8",
+			"repository": "https://sourceforge.net/projects/nppmenusearch/files/v0.9.6/NppMenuSearch_v0.9.6_x86.zip",
 			"description": "Adds a text field to the toolbar for searching menu items and preference dialog options.",
 			"author": "Peter Frentrup",
 			"homepage": "https://github.com/peter-frentrup/NppMenuSearch"


### PR DESCRIPTION
I just released version 0.9.5 of my NppMenuSearch plugin. fixes several bugs and implements some new features:

* NEW: corresponding menu icon or toolbar icon is displayed next to a result entry
* NEW: remember results window size after restart ([issue #23](https://github.com/peter-frentrup/NppMenuSearch/issues/23))
* NEW: support newer preference dialog pages
* FIX: better support for high resolution displays ([issue #24](https://github.com/peter-frentrup/NppMenuSearch/issues/24))
* FIX: display real shortcut instead of hard-coding CTRL+M in the help texts ([issue #22](https://github.com/peter-frentrup/NppMenuSearch/issues/22))
* FIX: work around duplicate dialog controls with same id ([issue #28](https://github.com/peter-frentrup/NppMenuSearch/issues/28))
* FIX: support hidden toolbar again ([issue #25](https://github.com/peter-frentrup/NppMenuSearch/issues/25)) Thanks to [Victor Istomin](https://github.com/victor-istomin)!
* FIX: open and select shortcuts editor window on x64

Peter