### PR TITLE
Random Values plug-in update v0.2.1

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -906,9 +906,9 @@
 		{
 			"folder-name": "RandomValuesNppPlugin",
 			"display-name": "Random Values",
-			"version": "0.2",
-			"id": "7d1423d4f670acfc57f8ac12410a532385feede2fe35d3ac42d66e206c20cdb6",
-			"repository": "https://github.com/BdR76/RandomValuesNPP/releases/download/0.2/RandomValuesNppPlugin-64bit.zip",
+			"version": "0.2.1",
+			"id": "b404204c47e5eccf621701c529499bf989b8a8adfb69a6d2cdfbcb5ff60ab3be",
+			"repository": "https://github.com/BdR76/RandomValuesNPP/releases/download/0.2.1/RandomValuesNppPlugin_x64.zip",
 			"description": "Random values generator for passwords or test data. Custom configurable string, integer, decimal, datetime, guid values based on range or mask. Single values for quick access or a list of multiple values at once in csv, xml, json, sql formats.",
 			"author": "Bas de Reuver",
 			"homepage": "https://github.com/BdR76/RandomValuesNPP/"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1186,9 +1186,9 @@
 		{
 			"folder-name": "RandomValuesNppPlugin",
 			"display-name": "Random Values",
-			"version": "0.2",
-			"id": "5fa3487edb4a111e8d6e3cc7150cfee1d44f94b2a53950d36a70769cd483035e",
-			"repository": "https://github.com/BdR76/RandomValuesNPP/releases/download/0.2/RandomValuesNppPlugin_32bit.zip",
+			"version": "0.2.1",
+			"id": "65f4fd342da9541801af1fb2a55c223d7708c5a0906d153606ef3c6b28ba0f64",
+			"repository": "https://github.com/BdR76/RandomValuesNPP/releases/download/0.2.1/RandomValuesNppPlugin_x86.zip",
 			"description": "Random values generator for passwords or test data. Custom configurable string, integer, decimal, datetime, guid values based on range or mask. Single values for quick access or a list of multiple values at once in csv, xml, json, sql formats.",
 			"author": "Bas de Reuver",
 			"homepage": "https://github.com/BdR76/RandomValuesNPP/"


### PR DESCRIPTION
Random Values plug-in update v0.2.1.

I appreciate that Notepad++ was updated just today to 8.1.9.1 to include some plug-in updates, including my CSV Lint plug-in update from yesterday, that last update v0.4.3 had some important bugfixes.

This Random Values plugin update is not as urgent, as it mainly adds the new fluent UI icons and some minor bugfixes, so as far as i am concerned there's no need to update Notepad++ immediately again, this one can wait for some update down the line somewhere. Cheers, Bas