### PR TITLE
NppGTags v4.5.0

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -716,9 +716,9 @@
 		{
 			"folder-name": "NppGTags",
 			"display-name": "NppGTags",
-			"version": "4.4.3",
-			"id": "8a1c9e11fa4d289428b1f5d9f2d8ac6b1fb68664d50314a98c1045700172cae0",
-			"repository": "https://github.com/pnedev/nppgtags/releases/download/v4.4.3/NppGTags_v4.4.3_x64.zip",
+			"version": "4.5.0",
+			"id": "316c188fa5537c6385185e3cdcd2f6c38b9db17a611651587769283ec3e1a9c2",
+			"repository": "https://github.com/pnedev/nppgtags/releases/download/v4.5.0/NppGTags_v4.5.0_x64.zip",
 			"description": "Front-end to GNU Global source code tagging system (GTags). Provides code indexing and search/navigation tools for various languages.",
 			"author": "Pavel Nedev",
 			"homepage": "https://github.com/pnedev/nppgtags"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -936,9 +936,9 @@
 		{
 			"folder-name": "NppGTags",
 			"display-name": "NppGTags",
-			"version": "4.4.3",
-			"id": "97ffe4ff1f957970985792d876ccde9a5f5d50fc86a6e51f56a5f0eba2975641",
-			"repository": "https://github.com/pnedev/nppgtags/releases/download/v4.4.3/NppGTags_v4.4.3_x86.zip",
+			"version": "4.5.0",
+			"id": "5ee40e46cb8649b85bebf69682e6e65580d1a8a16420b0529626db4ea33f0ee2",
+			"repository": "https://github.com/pnedev/nppgtags/releases/download/v4.5.0/NppGTags_v4.5.0_x86.zip",
 			"description": "Front-end to GNU Global source code tagging system (GTags). Provides code indexing and search/navigation tools for various languages.",
 			"author": "Pavel Nedev",
 			"homepage": "https://github.com/pnedev/nppgtags"


### PR DESCRIPTION
Reflects Notepad++ 8.2.2 and above header changes connected with 64-bit 2GB+ file access.