### PR TITLE
Update Papyrus Script Lexer plugin to v0.4.0.27 for both x64 and x86, to be compatible with the upcoming Notepad++ release after 8.3.3

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -901,11 +901,11 @@
 		{
 			"folder-name": "Papyrus",
 			"display-name": "Papyrus Script Lexer",
-			"version": "0.3.0.24",
+			"version": "0.4.0.27",
 			"npp-compatible-versions": "[8.3,]",
 			"old-versions-compatibility": "[,0.2.3.23][,8.2.1]",
-			"id": "1eef1096f4d239a525cd8c50cab5bfd3b49dd6b08cbeb230bebd63e51dc8d2a4",
-			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.3.0/PapyrusPlugin-v0.3.0-x64.zip",
+			"id": "296a2b0eca67e39fb361f600a25a44b51005dd7ad47c7df505fd2949b6f7ece0",
+			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.4.0/PapyrusPlugin-v0.4.0-x64.zip",
 			"description": "View and edit Papyrus Script files used by Bethesda games with syntax highlighting, function and block folding, hyperlinks to referenced scripts, keywords matching, plus compilation support with anonymized output and error list view.",
 			"author": "blu3mania",
 			"homepage": "https://github.com/blu3mania/npp-papyrus"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1066,9 +1066,9 @@
 		{
 			"folder-name": "Papyrus",
 			"display-name": "Papyrus Script Lexer",
-			"version": "0.3.0.24",
-			"id": "8f82500d6d4686c119cac769a46d090944e44a7428a1d5073d581a65701f61aa",
-			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.3.0/PapyrusPlugin-v0.3.0-x86.zip",
+			"version": "0.4.0.27",
+			"id": "619f7ac822d5fecee375d05e282728da906c2e7f9f74c1bacfd11beee431dca1",
+			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.4.0/PapyrusPlugin-v0.4.0-x86.zip",
 			"description": "View and edit Papyrus Script files used by Bethesda games with syntax highlighting, function and block folding, hyperlinks to referenced scripts, keywords matching, plus compilation support with anonymized output and error list view.",
 			"author": "blu3mania",
 			"homepage": "https://github.com/blu3mania/npp-papyrus"


### PR DESCRIPTION
Release page with VirusTotal scan results: https://github.com/blu3mania/npp-papyrus/releases

Latest CodeQL scan: https://github.com/blu3mania/npp-papyrus/actions/runs/2085580925

Note that VirusTotal has a less than 10% report rate of "Lazy" trojan on [PapyrusPlugin-v0.4.0-x86.zip](https://www.virustotal.com/gui/file-analysis/ZmU2M2NlZDM3ZWRiNzAxMWM0ZGYxYTAyZjFkZmFiZjQ6MTY0ODk5Njk1Ng==/detection), which is a false alarm. Originally there were 8 reports so I moved a method around, which got the number of reports down to 4 but didn't get rid of it. Since it's an obvious false alarm because the same builder is used for both x86 and x64 builds, and there has been no report on [PapyrusPlugin-v0.4.0-x64.zip](https://www.virustotal.com/gui/file-analysis/ZDA5YTkzOTM5YTQ3ZDZjYTc4OTZmZjhhMGU3ZDY5YWM6MTY0ODk5Njk2Ng==/detection), I am not going to bother with it.