### PR TITLE
CS-Script Update v2.0.1.0

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -193,11 +193,11 @@
 		{
 			"folder-name": "CSScriptNpp",
 			"display-name": "CS-Script - C# Intellisense",
-			"version": "2.0.0.0",
+			"version": "2.0.1.0",
 			"npp-compatible-versions": "[8.3,]",
 			"old-versions-compatibility": "[,1.7.26][,8.2.1]",
-			"id": "df49aa3a7dfdec8b10bf74610ef02c0da89d6635beeaed957720a75a3dcd1ffa",
-			"repository": "https://github.com/oleg-shilo/cs-script.npp/releases/download/v2.0.0.0/CSScriptNpp.2.0.0.0.x64.zip",
+			"id": "ae385e7aa190bb013ccb4ed0805c946ea459f4d8c820d00c871806c9989c6787",
+			"repository": "https://github.com/oleg-shilo/cs-script.npp/releases/download/v2.0.1.0/CSScriptNpp.2.0.1.0.x64.zip",
 			"description": "CS-Script integration. Implements a real C# Intellisense solution based on CS-Script and Roslyn. Allows loading, executing modifying and debugging C# scripts in a way very similar to the Visual Studio C# projects support. This includes referencing assemblies and other scripts, code formatting, adding missing namespaces and intercepting Debug and Console output.",
 			"author": "Oleg Shilo",
 			"homepage": "https://github.com/oleg-shilo/cs-script.npp"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -186,9 +186,9 @@
 		{
 			"folder-name": "CSScriptNpp",
 			"display-name": "CS-Script - C# Intellisense",
-			"version": "2.0.0.0",
-			"id": "94483a70709e79c8dd16a8fd5b26bf780398ee0f54f948cb5945e1f2346de246",
-			"repository": "https://github.com/oleg-shilo/cs-script.npp/releases/download/v2.0.0.0/CSScriptNpp.2.0.0.0.x86.zip",
+			"version": "2.0.1.0",
+			"id": "2a5f9d17dc86d8d4c3dea55c5d7d3f5067720dca67f7560454e9bf7463801f10",
+			"repository": "https://github.com/oleg-shilo/cs-script.npp/releases/download/v2.0.1.0/CSScriptNpp.2.0.1.0.x86.zip",
 			"description": "CS-Script integration. Implements a real C# Intellisense solution based on CS-Script and Roslyn. Allows loading, executing modifying and debugging C# scripts in a way very similar to the Visual Studio C# projects support. This includes referencing assemblies and other scripts, code formatting, adding missing namespaces and intercepting Debug and Console output.",
 			"author": "Oleg Shilo",
 			"homepage": "https://github.com/oleg-shilo/cs-script.npp"


### PR DESCRIPTION
- Improved Npp compatibility checking (Issue #64).
  Required to correctly assess N++ v8.4 compatibility
