### PR TITLE
New plugin for JSON linting, querying, editing, JSON-to-CSV conversion

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -490,7 +490,8 @@
 			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v3.0.0.0/Release_x64.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, a JMESpath-like query language, and much more",
 			"author": "Mark Johnston Olson",
-			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin"
+			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",
+			"npp-compatible-versions": "[8.4.1,]"
 		},
 		{
 			"folder-name": "NPPJSONViewer",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -483,6 +483,16 @@
 			"homepage": "https://github.com/davidsover/nppJSFunctionViewer"
 		},
 		{
+			"folder-name": "JsonTools",
+			"display-name": "JSON Tools",
+			"version": "3.0.0.0",
+			"id": "fb07eefac652ac72af98f226dac5174a3542815c64df66fbbeb35e7c9c2ea3da",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v3.0.0.0/Release_x64.zip",
+			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, a JMESpath-like query language, and much more",
+			"author": "Mark Johnston Olson",
+			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin"
+		},
+		{
 			"folder-name": "NPPJSONViewer",
 			"display-name": "JSON Viewer",
 			"version": "1.40",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -579,6 +579,16 @@
 			"homepage": "https://sourceforge.net/projects/jslintnpp/"
 		},
 		{
+			"folder-name": "JsonTools",
+			"display-name": "JSON Tools",
+			"version": "3.0.0.0",
+			"id": "9b5d8e3a680a777c415f5030eb1b8efa1834be6b84701cf7de1ee38eb4b618ed",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v3.0.0.0/Release_x86.zip",
+			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, a JMESpath-like query language, and much more",
+			"author": "Mark Johnston Olson",
+			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin"
+		},
+		{
 			"folder-name": "NPPJSONViewer",
 			"display-name": "JSON Viewer",
 			"version": "1.40",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -586,7 +586,8 @@
 			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v3.0.0.0/Release_x86.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, a JMESpath-like query language, and much more",
 			"author": "Mark Johnston Olson",
-			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin"
+			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",
+			"npp-compatible-versions": "[8.4.1,]"
 		},
 		{
 			"folder-name": "NPPJSONViewer",


### PR DESCRIPTION
Works on 8.4.1+ of both 32bit and 64bit. Inspired by Kapilratnani's popular and excellent [JSON Viewer](https://github.com/kapilratnani/JSON-Viewer) with an aim towards addressing some of the main unresolved issues and enhancement requests.

Also includes a query language that makes it easy to find (and replace if desired) places in the JSON tree based on the tree structure.

Can be used to make CSVs or YAML from JSON. A JSON Schema creator is in the works, but it has some bugs that need fixing.