### PR TITLE
RunMe v1.60

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -611,9 +611,9 @@
 			"folder-name": "MenuIcons",
 			"display-name": "MenuIcons",
 			"version": "1.2.5",
-			"id": "6f2b909cf2468a1a16b443d004cad107e56a67a7e56dcb6f39792bbbfaacfbdc",
-			"repository": "https://github.com/francostellari/NppPlugins/raw/main/MenuIcons/MenuIcons_dll_1v25_x64.zip",
-			"description": "Allows adding icons to both main and context menu. Several options are available to load the icons from a folder. More than provide a full set of icons, it's design to enable people to create their own set of icon themes. Note: Does not work correctly in WinXP.",
+			"id": "f894da2b29ae48476cd6add4550ad4b284bcb6f01a54479866218a5e6f7e7310",
+			"repository": "https://github.com/francostellari/NppPlugins/raw/main/MenuIcons/MenuIcons_dll_2v00_x64.zip",
+			"description": "Adds icons to the main menu, tab menu, context menu, and the tabs themselves.",
 			"author": "Franco Stellari",
 			"homepage": "https://github.com/francostellari/NppPlugins"
 		},

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1328,9 +1328,9 @@
 		{
 			"folder-name": "TopMost",
 			"display-name": "TopMost",
-			"version": "1.4.0.0",
-			"id": "1c211bd5b14b50420b7238377dd001bda7d5d86941a9521ba6f7ba85599decca",
-			"repository": "https://github.com/francostellari/NppPlugins/raw/main/TopMost/TopMost_dll_1v40_x64.zip",
+			"version": "1.4.1.0",
+			"id": "6fab7cc42fce5a7e66e301b502d7e4ed492312c88c168fa9c2a53a7f9e22b083",
+			"repository": "https://github.com/francostellari/NppPlugins/raw/main/TopMost/TopMost_dll_1v41_x64.zip",
 			"description": "Allows setting the main Notepad++ window as a topmost window so it can stay on top of other windows even when it is not active. Syncs with Notepad++'s own stay on top functionality and allows to remember the setting between restarts as well as to show a toolbar button.",
 			"author": "Franco Stellari",
 			"homepage": "https://github.com/francostellari/NppPlugins"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1129,9 +1129,9 @@
 		{
 			"folder-name": "RunMe",
 			"display-name": "RunMe",
-			"version": "1.4.1.0",
-			"id": "f49e2cd6796a5a1b49655aaa1ba5c3574fbfa0b33e51d9a585cbf0603be27e78",
-			"repository": "https://github.com/francostellari/NppPlugins/raw/main/RunMe/RunMe_dll_1v41_x64.zip",
+			"version": "1.6.0.0",
+			"id": "1e7549e5f1a9cdb96ebf7d90271c1f5ff94081154139f056154a02679dc1157c",
+			"repository": "https://github.com/francostellari/NppPlugins/raw/main/RunMe/RunMe_dll_1v60_x64.zip",
 			"description": "Execute the currently open file, based on its shell association. Also allows opening an explorer or command shell at the file location. Options are available to save the current file (or all files) before execution. The executed file can be run in foreground, background, or hidden mode. Context menu entries and tool bar icons are available.",
 			"author": "Franco Stellari",
 			"homepage": "https://github.com/francostellari/NppPlugins"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -610,7 +610,7 @@
 		{
 			"folder-name": "MenuIcons",
 			"display-name": "MenuIcons",
-			"version": "1.2.5",
+			"version": "2.0.0",
 			"id": "f894da2b29ae48476cd6add4550ad4b284bcb6f01a54479866218a5e6f7e7310",
 			"repository": "https://github.com/francostellari/NppPlugins/raw/main/MenuIcons/MenuIcons_dll_2v00_x64.zip",
 			"description": "Adds icons to the main menu, tab menu, context menu, and the tabs themselves.",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1302,9 +1302,9 @@
 		{
 			"folder-name": "RunMe",
 			"display-name": "RunMe",
-			"version": "1.4.1.0",
-			"id": "2b0197fbf1dc5927726cf6c5801f1c74693ee6f2011194a83369bb82ee0b16aa",
-			"repository": "https://github.com/francostellari/NppPlugins/raw/main/RunMe/RunMe_dll_1v41_x32.zip",
+			"version": "1.6.0.0",
+			"id": "fec92058a3470b1821c0aa6b0831650da2d6f42c9543775cb511239e6b926f06",
+			"repository": "https://github.com/francostellari/NppPlugins/raw/main/RunMe/RunMe_dll_1v60_x32.zip",
 			"description": "Execute the currently open file, based on its shell association. Also allows opening an explorer or command shell at the file location. Options are available to save the current file (or all files) before execution. The executed file can be run in foreground, background, or hidden mode. Context menu entries and tool bar icons are available.",
 			"author": "Franco Stellari",
 			"homepage": "https://github.com/francostellari/NppPlugins"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -715,10 +715,10 @@
 		{
 			"folder-name": "MenuIcons",
 			"display-name": "MenuIcons",
-			"version": "1.2.5",
-			"id": "f503e1398703997dbdbdebdb659c99e490d01493d9ef1a121e9e7f15ec60824c",
-			"repository": "https://github.com/francostellari/NppPlugins/raw/main/MenuIcons/MenuIcons_dll_1v25_x32.zip",
-			"description": "Allows adding icons to both main and context menu. Several options are available to load the icons from a folder. More than provide a full set of icons, it's design to enable people to create their own set of icon themes. Note: Does not work correctly in WinXP.",
+			"version": "2.0.0",
+			"id": "5fa472cfd3b5de2c7ff2d117201e95f2183c58c1f02f31c9bc46bfa2c4d864bf",
+			"repository": "https://github.com/francostellari/NppPlugins/raw/main/MenuIcons/MenuIcons_dll_2v00_x32.zip",
+			"description": "Adds icons to the main menu, tab menu, context menu, and the tabs themselves.",
 			"author": "Franco Stellari",
 			"homepage": "https://github.com/francostellari/NppPlugins"
 		},

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1563,9 +1563,9 @@
 		{
 			"folder-name": "TopMost",
 			"display-name": "TopMost",
-			"version": "1.4.0.0",
-			"id": "4e68fdd5ac499b2bbe885d3d6283d8d43e610cfa6e60f306f42ecdb9f8438e5a",
-			"repository": "https://github.com/francostellari/NppPlugins/raw/main/TopMost/TopMost_dll_1v40_x32.zip",
+			"version": "1.4.1.0",
+			"id": "ee71f6d1e1fe8c04c4b3715f764930172989b4b3be640ee72ac6a685735365a4",
+			"repository": "https://github.com/francostellari/NppPlugins/raw/main/TopMost/TopMost_dll_1v41_x32.zip",
 			"description": "Allows setting the main Notepad++ window as a topmost window so it can stay on top of other windows even when it is not active. Syncs with Notepad++'s own stay on top functionality and allows to remember the setting between restarts as well as to show a toolbar button.",
 			"author": "Franco Stellari",
 			"homepage": "https://github.com/francostellari/NppPlugins"


### PR DESCRIPTION
* Added: menu icons for "Run with arguments" and "Run as administrator"
* Added: Toolbar entries for "Run with arguments" and "Run as administrator"
* Added: Tab context menu entries for "Run with arguments" and "Run as administrator"
* Added: Run me with a custom *verb*
* Fix: Cancelling a "Run me w/ arguments" would not stop the run
* Fix: Remove the tab flickering for save all unamed buffers before running