### PR TITLE
Update Papyrus Script Lexer plugin to v0.5.1.30 for both x64 and x86

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1005,11 +1005,11 @@
 		{
 			"folder-name": "Papyrus",
 			"display-name": "Papyrus Script Lexer",
-			"version": "0.5.0.28",
+			"version": "0.5.1.30",
 			"npp-compatible-versions": "[8.3,]",
 			"old-versions-compatibility": "[,0.2.3.23][,8.2.1]",
-			"id": "88aad3e5492ba290499e90ea596645a70a1b7834b7140436e084ad784a309707",
-			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.5.0/PapyrusPlugin-v0.5.0-x64.zip",
+			"id": "e7cffb2aba82fc7418b587d577eeac96bb602105409a803f0618161992db6635",
+			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.5.1/PapyrusPlugin-v0.5.1-x64.zip",
 			"description": "View and edit Papyrus Script files used by Bethesda games with syntax highlighting, function and block folding, hyperlinks to referenced scripts, keywords matching, plus compilation support with anonymized output and error list view.",
 			"author": "blu3mania",
 			"homepage": "https://github.com/blu3mania/npp-papyrus"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1137,9 +1137,9 @@
 		{
 			"folder-name": "Papyrus",
 			"display-name": "Papyrus Script Lexer",
-			"version": "0.5.0.28",
-			"id": "b6a7d2648da89745bfa2206b03a02286a72005a498018793e86945d61e84d5da",
-			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.5.0/PapyrusPlugin-v0.5.0-x86.zip",
+			"version": "0.5.1.30",
+			"id": "0624e64d620f31ce73fa69c570f14f36c63efc6c85d3a0cc2f0d9a811c5e3750",
+			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v0.5.1/PapyrusPlugin-v0.5.1-x86.zip",
 			"description": "View and edit Papyrus Script files used by Bethesda games with syntax highlighting, function and block folding, hyperlinks to referenced scripts, keywords matching, plus compilation support with anonymized output and error list view.",
 			"author": "blu3mania",
 			"homepage": "https://github.com/blu3mania/npp-papyrus"


### PR DESCRIPTION
Release page with VirusTotal scan results: https://github.com/blu3mania/npp-papyrus/releases

Latest CodeQL scan: https://github.com/blu3mania/npp-papyrus/actions/runs/3575174400