### PR TITLE
Update Elastic Tabstops to version 1.5.0

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -309,13 +309,14 @@
 		{
 			"folder-name": "ElasticTabstops",
 			"display-name": "ElasticTabstops",
-			"version": "1.3.1",
-			"npp-compatible-versions": "[,8.2.1]",
-			"id": "657f343f135e9af2d9db8b94dee991ff0c3931151ed7faea3a40822c0bc295a6",
-			"repository": "https://github.com/dail8859/ElasticTabstops/releases/download/v1.3.1/ElasticTabstops_v1.3.1_x64.zip",
+			"version": "1.5.0",
+			"npp-compatible-versions": "[8.4.4,]",
+			"old-versions-compatibility": "[,1.3][,8.2.1]",
+			"id": "48f94a2691d0926ab0c6ac10e23d4a4cdc79b7fa468ed6b0b172fa8de79166fd",
+			"repository": "https://github.com/mariusv-github/ElasticTabstops/releases/download/v1.5.0/ElasticTabstops_x64_1.5.0.zip",
 			"description": "Support for Elastic Tabstops.",
-			"author": "Justin Dailey",
-			"homepage": "https://github.com/dail8859/ElasticTabstops"
+			"author": "Marius Vasiliu, Justin Dailey",
+			"homepage": "https://github.com/mariusv-github/ElasticTabstops"
 		},
 		{
 			"folder-name": "EnhanceAnyLexer",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -316,12 +316,14 @@
 		{
 			"folder-name": "ElasticTabstops",
 			"display-name": "ElasticTabstops",
-			"version": "1.3.1",
-			"id": "4ed9a765181e8398c0b5acf465281451a5388a7f35277324f9d5a297011d5c4e",
-			"repository": "https://github.com/dail8859/ElasticTabstops/releases/download/v1.3.1/ElasticTabstops_v1.3.1.zip",
+			"version": "1.5.0",
+			"npp-compatible-versions": "[8.4.4,]",
+			"old-versions-compatibility": "[,1.3][,8.2.1]",
+			"id": "5033bea9de694c6de055e40fd19ce739a5a147b5fd9eae2008e0a00cad439db3",
+			"repository": "https://github.com/mariusv-github/ElasticTabstops/releases/download/v1.5.0/ElasticTabstops_x86_1.5.0.zip",
 			"description": "Support for Elastic Tabstops.",
-			"author": "Justin Dailey",
-			"homepage": "https://github.com/dail8859/ElasticTabstops"
+			"author": "Marius Vasiliu, Justin Dailey",
+			"homepage": "https://github.com/mariusv-github/ElasticTabstops"
 		},
 		{
 			"folder-name": "EnhanceAnyLexer",


### PR DESCRIPTION
Update Elastic Tabstops to version 1.5.0 for x86 and x64 code.