### PR TITLE
 Update to File Finder v0.3

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -369,6 +369,16 @@
 			"homepage": "https://sourceforge.net/projects/extsettings"
 		},
 		{
+			"folder-name": "FileFinder",
+			"display-name": "FileFinder",
+			"version": "0.2",
+			"id": "66fd778dd2b3c4847b7aada9600daf5229560cc4fd5789890020c48dd1b27e57",
+			"repository": "https://bitbucket.org/uph0/filefinder/downloads/FileFinder.v0.2.0.x64.bin.zip",
+			"description": "Quickly and comfortably find files by name, both in folders and in N++'s file history.",
+			"author": "UFO-Pu55y",
+			"homepage": "https://bitbucket.org/uph0/filefinder"
+		},
+		{
 			"folder-name": "FWDataViz",
 			"display-name": "Fixed-width Data Visualizer",
 			"version": "2.6.1.0",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -373,7 +373,7 @@
 			"folder-name": "FileFinder",
 			"display-name": "FileFinder",
 			"version": "0.3",
-			"id": "e75066ff9d7d3e9cabb2195260433adffc08751668ca48e1cd1c16776a81dad6",
+			"id": "9582adb0d78e550d1dc0ad13c463b3a3c442bc1db43a7301c55c8b34a256e25c",
 			"repository": "https://bitbucket.org/uph0/filefinder/downloads/FileFinder.v0.3.0.x64.bin.zip",
 			"description": "Quickly and comfortably find files by name, both in folders and in N++'s file history.",
 			"author": "UFO-Pu55y",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1288,6 +1288,16 @@
 			"homepage": "https://www.incrediblejunior.com/npp_plugins/"
 		},
 		{
+			"folder-name": "SourceCookifier",
+			"display-name": "Source Cookifier",
+			"version": "0.10.0",
+			"id": "c05b50c4a4a346681a170d18eda8dbddc2c295ae3b3a248ac0f5859c84c0c273",
+			"repository": "https://bitbucket.org/uph0/sourcecookifier/downloads/SourceCookifier.v0.10.0.x64.bin.zip",
+			"description": "Use Exuberant Ctags to parse either only the currently activated source file or multiple files. The results are shown and can be browsed in a treeview inside of a dockable window. (Requires .NET)",
+			"author": "UFO-Pu55y",
+			"homepage": "https://bitbucket.org/uph0/sourcecookifier/"
+		},
+		{
 			"folder-name": "SpeechPlugin",
 			"display-name": "SpeechPlugin",
 			"version": "0.4.0.0",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -372,9 +372,9 @@
 		{
 			"folder-name": "FileFinder",
 			"display-name": "FileFinder",
-			"version": "0.2",
-			"id": "66fd778dd2b3c4847b7aada9600daf5229560cc4fd5789890020c48dd1b27e57",
-			"repository": "https://bitbucket.org/uph0/filefinder/downloads/FileFinder.v0.2.0.x64.bin.zip",
+			"version": "0.3",
+			"id": "e75066ff9d7d3e9cabb2195260433adffc08751668ca48e1cd1c16776a81dad6",
+			"repository": "https://bitbucket.org/uph0/filefinder/downloads/FileFinder.v0.3.0.x64.bin.zip",
 			"description": "Quickly and comfortably find files by name, both in folders and in N++'s file history.",
 			"author": "UFO-Pu55y",
 			"homepage": "https://bitbucket.org/uph0/filefinder"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1463,7 +1463,7 @@
 			"version": "0.7.3",
 			"id": "ccc0e93ddb580511b5c2b4a3363713ef0cd96187515e972362bf5b6b235430de",
 			"repository": "https://downloads.sourceforge.net/project/sourcecookifier/0.7.3/SourceCookifier.v0.7.3.bin.zip",
-			"description": "Use Exuberant Ctags to parse either only the currently activated source file or multiple files. The results are shown and can be browsed in a treeview inside of a dockable window. (Requires .NET 2.0)",
+			"description": "Use Exuberant Ctags to parse either only the currently activated source file or multiple files. The results are shown and can be browsed in a treeview inside of a dockable window. (Requires .NET 2.0) NOTE: The 32 bit version has been discontinued.",
 			"author": "UFO-Pu55y",
 			"homepage": "https://sourceforge.net/projects/sourcecookifier/"
 		},


### PR DESCRIPTION
File Finder v0.3

- Bugfix: 'Auto validate file names' doesn't remove non-existing files from internal file list