### PR TITLE
Update JsonTools to 4.8.1; JSON schema stuff

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -536,10 +536,10 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "4.4.0.0",
-			"id": "82a4aa4333efce934af80f025286c1d257cc3127ac30909a646f5ed7003b8978",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.4/Release_x64.zip",
-			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, a JMESpath-like query language, and much more",
+			"version": "4.8.1.0",
+			"id": "00c50c970a00dbeaa1e38777a0b8eb12cc3a6f611795bd2adce614960d4e22fc",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.8.1/Release_x64.zip",
+			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, and much more",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",
 			"npp-compatible-versions": "[8.4.1,]"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -604,10 +604,10 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "4.4.0.0",
-			"id": "c637175f585762e8ed1fe469f3bf577bb8f9d35eded69d538f15f1ea459dad72",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.4/Release_x86.zip",
-			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, a JMESpath-like query language, and much more",
+			"version": "4.8.1.0",
+			"id": "69c1ef1b88051186d42e1ddc48196ac8fdc889487e280f367509377bf599a444",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.8.1/Release_x86.zip",
+			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, and much more",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",
 			"npp-compatible-versions": "[8.4.1,]"


### PR DESCRIPTION
## [4.8.1] - 2022-12-26

### Added

1. [Random JSON generation](/docs/README.md#generating-random-json-from-a-schema) from a non-schema file.
2. Tests for random JSON generation.

### Fixed

1. Bug with random JSON generation where *all keys* (including *non-required keys*) in an object schema would always be included in random JSON. Now each object will have a random set of keys that is a superset of the required keys and a subset of all validated keys.

## [4.8.0] - 2022-12-22

### Added

1. [JSON Schema generation](/docs/README.md#generating-json-schema-from-json) is back!

## [4.7.0] - 2022-12-20

### Added

1. Support for extended ASCII characters (i.e., anything from `0x7f` (⌂) to `0xff` (ÿ)) in random JSON.

### Changed

1. Non-ASCII characters (e.g., 😀, Я) are now displayed normally rather than being converted to ASCII using the `\u` notation (e.g., `\ud83d\ude00`, `\u042f`). Resolve [Issue #25](https://github.com/molsonkiko/JsonToolsNppPlugin/issues/25).

### Fixed

1. Fix bug where [find/replace form](/docs/README.md#find-and-replace-form) advanced controls would not be toggled if the user manually resized the form.

## [4.6.1] - 2022-12-11

### Fixed

1. Fixed bugs where renaming a tree view (including the GrepperForm tree view) would cause problems, including a plugin crash upon closing Notepad++.
	- Such crash bugs still seem to appear under conditions that I cannot reliably replicate, but they are rare and innocuous.

## [4.6.0] - 2022-12-09

### Added

1. [JSON schema validation](/docs/README.md#validating-json-against-json-schema).
2. [Generation of random JSON from a schema](/docs/README.md#generating-random-json-from-a-schema).

### Fixed

1. Bugs with handling of binops in RemesPath. Also cleaned up the tests of `log` and `log2`. The longest-standing known bugs in RemesPath are finally squashed!

## [4.5.0] - 2022-12-06

### Added

1. Memory of past JSON from files+apis form directories chosen.

### Fixed

2. When files are removed from the grepper form, the text in the associated buffer is refreshed with the pruned JSON.