### PR TITLE
up JsonTools to 4.11.1, fix crash bug in 4.11.0

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -538,9 +538,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "4.11.0",
-			"id": "a745a186e028220868b3f688fac74a2a009b4d89a84a3621d86d034af3f189c3",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.11.0/Release_x64.zip",
+			"version": "4.11.1",
+			"id": "b8c0d1cff04cc081069522e2ec8d1ef70653b4413f88baaf990d192d786e61be",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.11.1/Release_x64.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, and much more",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -616,9 +616,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "4.11.0",
-			"id": "b07785b1334368ebc045dbdbda4f0bce8b9d9d7e2187391b329bfdaf29300640",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.11.0/Release_x86.zip",
+			"version": "4.11.1",
+			"id": "5840f859ab8ff12dce6ccc0d565ca72b3c24f6610b7c374ccb27ea215c1ba593",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.11.1/Release_x86.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, and much more",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",


### PR DESCRIPTION
Address [JsonTools issue 30](https://github.com/molsonkiko/JsonToolsNppPlugin/issues/30)
Release link [here](https://github.com/molsonkiko/JsonToolsNppPlugin/releases/tag/v4.11.1)