### PR TITLE
validator.py: Output empty lines in plugin list Markdown generation (issue #603)

### DIFF
--- a/validator.py
+++ b/validator.py
@@ -25,7 +25,7 @@ tmpl_new_line = '\n'
 tmpl_tr_b = '| '
 tmpl_td   = ' | '
 tmpl_tr_e = ' |'
-tmpl_tab_head = '''|Plugin name | Author | Homepage | Version and link | Description |
+tmpl_tab_head = '''| Plugin name | Author | Homepage | Version and link | Description |
 |---|---|---|---|---|
 '''
 
@@ -69,8 +69,8 @@ def rest_of_text(description):
 def gen_pl_table(filename):
     pl = json.loads(open(filename).read())
     arch = pl["arch"]
-    tab_text = "## Plugin List - %s bit%s" % (arch, tmpl_new_line)
-    tab_text += "version %s%s" % (pl["version"], tmpl_new_line)
+    tab_text = "## Plugin List - %s bit%s" % (arch, tmpl_new_line * 2)
+    tab_text += "version %s%s" % (pl["version"], tmpl_new_line * 2)
     tab_text += tmpl_tab_head
 
     # Plugin Name = ij.display-name


### PR DESCRIPTION
Improve Markdown table syntax compatibility of [`doc/plugin_list*.md` files](https://github.com/notepad-plus-plus/nppPluginList/tree/master/doc) by editing the `validator.py` Markdown generation:

- Place empty lines between the heading, paragraph (mentioning the version), and the table. Without the empty line before the table, some Markdown implementations might not detect the table.

- Additional change for the table header row: add one space between "*Plugin name*" and the `|` character before it.

See issue notepad-plus-plus/nppPluginList#603 for more information.

## Testing

The automatically queued AppVeyor build has finished and the artifacts are available. The Markdown files in the artifacts show that these changes work as I intended.

Testing before the AppVeyor build: I tried the `*` operator with Python's "old style" string formatting (together with the `%` operator).

<https://docs.python.org/3/library/stdtypes.html#string-methods>:

> Strings implement all of the [common](https://docs.python.org/3/library/stdtypes.html#typesseq-common) sequence operations

<https://docs.python.org/3/library/stdtypes.html#typesseq-common>:

> `s * n or n * s`: equivalent to adding *s* to itself *n* times
