### PR TITLE
Update F# Interactive to 0.2.1.1

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -383,6 +383,17 @@
 			"homepage": "https://sourceforge.net/projects/extsettings"
 		},
 		{
+			"folder-name": "NPPFSIPlugin",
+			"display-name": "F# Interactive",
+			"version": "0.2.1.1",
+			"npp-compatible-versions": "[7.7,]",
+			"id": "7d2f90a644345a5c0523c2e4522f735f28705811298e59496f53aa4a0144897a",
+			"repository": "https://github.com/rdipardo/nppFSIPlugin/releases/download/v0.2.1.1/NPPFSIPlugin_v0.2.1.1_x64.zip",
+			"description": "F# source code lexer and IPC client for F# Interactive.\r\nNote: the .NET SDK must be installed separately.",
+			"author": "Prapin Peethambaran",
+			"homepage": "https://github.com/rdipardo/nppFSIPlugin"
+		},
+		{
 			"folder-name": "FileFinder",
 			"display-name": "FileFinder",
 			"version": "0.3",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -393,12 +393,13 @@
 		{
 			"folder-name": "NPPFSIPlugin",
 			"display-name": "F# Interactive",
-			"version": "0.1.1",
-			"id": "894c89d401c668f76aabe20bf37cadcec26418bfc57fe275687615e8af759810",
-			"repository": "https://github.com/downloads/ppv/NPPFSIPlugin/NPPFSIPlugin.zip",
-			"description": "Hosts F# Interactive inside Notepad++. Note: F# should be installed separately.",
+			"version": "0.2.1.1",
+			"npp-compatible-versions": "[7.7,]",
+			"id": "f0401e31da90b7baa504ba841d6ff21f1f28cbad139480cb00adc30a49567a92",
+			"repository": "https://github.com/rdipardo/nppFSIPlugin/releases/download/v0.2.1.1/NPPFSIPlugin_v0.2.1.1_win32.zip",
+			"description": "F# source code lexer and IPC client for F# Interactive.\r\nNote: the .NET SDK must be installed separately.",
 			"author": "Prapin Peethambaran",
-			"homepage": "https://github.com/ppv/NPPFSIPlugin"
+			"homepage": "https://github.com/rdipardo/nppFSIPlugin"
 		},
 		{
 			"folder-name": "FallingBricks",


### PR DESCRIPTION

The [original plugin host](https://github.com/ppv/NPPFSIPlugin) appears to be dormant.

Meanwhile, [my fork](https://github.com/rdipardo/nppFSIPlugin#readme) has added 64-bit compatibility, integration with Lexilla's [F# lexer], a dark mode theme, and better default settings for current versions of the .NET SDK.

The code base was ported to Free Pascal so releases can be [built in CI] with a free and open source toolchain. There may even be an ARM build someday, when/if the Free Pascal compiler makes Windows on ARM64 an [officially supported target].

Old and new plugin code is under the original MIT license; library units are licensed under the (L)GPL v3 or MPL v2, depending on which project they were extracted from.

I haven't formally asked @ppv about taking over. I could change the name, but then the old 32-bit versions out there would miss the upgrade. This plugin doesn't have enough users to make it much of an issue in any case. Most F# devs use VS Code these days.


[F# lexer]: https://github.com/notepad-plus-plus/notepad-plus-plus/blob/master/lexilla/lexers/LexFSharp.cxx
[officially supported target]: https://lists.freepascal.org/pipermail/fpc-announce/2020-April/000614.html
[built in CI]: https://app.circleci.com/pipelines/github/rdipardo/nppFSIPlugin/20/workflows/5b55b646-ecf0-4747-9724-f8341ed2e308/jobs/21/artifacts