### PR TITLE
update JsonTools to 4.14.0

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -549,9 +549,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "4.11.1",
-			"id": "b8c0d1cff04cc081069522e2ec8d1ef70653b4413f88baaf990d192d786e61be",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.11.1/Release_x64.zip",
+			"version": "4.14.0",
+			"id": "9c0f4f7e811b0aeac3ffebdccfcf0f4ac8c381ff5f12c77edd25b1209f45db02",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.14.0/Release_x64.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, and much more",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -617,9 +617,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "4.11.1",
-			"id": "5840f859ab8ff12dce6ccc0d565ca72b3c24f6610b7c374ccb27ea215c1ba593",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.11.1/Release_x86.zip",
+			"version": "4.14.0",
+			"id": "2a01b36f2c9f40742952f57fad16de8b23d574e41fcbe5a862aa941af88cdc68",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.14.0/Release_x86.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, and much more",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",


### PR DESCRIPTION
### Major changes

1. HUGE tree view performance improvement
2. Automatic error checking after user edits file
3. Many more JSON schema keywords supported
4. UI improvements
    - removed annoying dinging in tree view
    - some UI elements are bigger
5. Python-style `#` comments now can be ignored when parsing
6. Better performance in general