### PR TITLE
Update JsonTools to v5.0.0

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -549,9 +549,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "4.14.0",
-			"id": "9c0f4f7e811b0aeac3ffebdccfcf0f4ac8c381ff5f12c77edd25b1209f45db02",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.14.0/Release_x64.zip",
+			"version": "5.0.0",
+			"id": "ed555783878699d27c0e30e050c4c942658a63a0b93f6728ba80adb47844b08e",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v5.0.0/Release_x64.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, and much more",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -617,9 +617,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "4.14.0",
-			"id": "2a01b36f2c9f40742952f57fad16de8b23d574e41fcbe5a862aa941af88cdc68",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v4.14.0/Release_x86.zip",
+			"version": "5.0.0",
+			"id": "c7124c99d7432717c02fe4e7af0cf19573c7da66a0cd7f1abfa1f35514fe4087",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v5.0.0/Release_x86.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, and much more",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",


### PR DESCRIPTION
## Major changes
* Parser is faster and can handle more deviations from the JSON standard, including unquoted keys, hex numbers, and the `undefined`, `True`, `False`, and `None` literals
* User does not need to enable special options to allow parsing of error-ridden documents
* RemesPath has better error handling and messages
* Miscellaneous bugfixes
* JSON Schema validation now supports `minLength` and `maxLength` properties for strings.