### PR TITLE
Bump JsonTools to v5.4.0

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -549,9 +549,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "5.0.0",
-			"id": "ed555783878699d27c0e30e050c4c942658a63a0b93f6728ba80adb47844b08e",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v5.0.0/Release_x64.zip",
+			"version": "5.4.0",
+			"id": "a516d2176fafd5702d5b8414b12049fc6cace94b69cd640b56345730476899e5",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v5.4.0/Release_x64.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, and much more",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -617,9 +617,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "5.0.0",
-			"id": "c7124c99d7432717c02fe4e7af0cf19573c7da66a0cd7f1abfa1f35514fe4087",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v5.0.0/Release_x86.zip",
+			"version": "5.4.0",
+			"id": "099d7a4677f5a683c56518a15ae04adc6c416d742860e74561ac65c1268ca7aa",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v5.4.0/Release_x86.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, and much more",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",


### PR DESCRIPTION
## [5.4.0] - 2023-07-04

### Added

1. Added support for tab indentation. Fix [issue #38](https://github.com/molsonkiko/JsonToolsNppPlugin/issues/38).
2. Hitting `Enter` while in the error form causes the form to refresh.
3. In the error form, searching for the next row starting with a character now wraps around.
4. Python constants `nan` and `inf` can now be parsed as `NaN` and `Infinity` respectively.
5. Support for numbers with leading decimal points and hex numbers in RemesPath.
6. Unquoted strings in RemesPath can now contain leading `$`, Unicode escapes, and all the Unicode characters that are allowed in unquoted JSON5 keys.
7. Add caching of RemesPath queries for slightly better performance on repeated execution of the same query.
8. Massively impreoved test coverage.

### Changed

1. All arithmetic operations (`+`, `-`, `*`, `/`, `%`, and `//`) [can now accept booleans as one or both of their operands](/docs/RemesPath.md#binary-operators-unary-operators-and-arithmetic).
2. [`not` is now a unary operator](/docs/RemesPath.md#unary-operators) like `-` (that is, `not not @` is a valid statement, no parens needed). It also now tests "truthiness" like the same operator in Python.

### Fixed

1. Bugs with operator precedence in RemesPath.
2. Bugs with array and string slicing in RemesPath.
3. Uncaught errors when parsing integers too large for the floating point spec (e.g., one followed by 400 zeros)
4. Minor bug when scrolling up with the up arrow on error form.
5. More appropriately silly error handling when dogeifying JSON.

## [5.3.0] - 2023-06-10

### Added

1. New [error form](/docs/README.md#error-form-and-status-bar) for viewing syntax errors.
2. When JSON is parsed, the [document type status bar section changes](/docs/README.md#error-form-and-status-bar) to reflect the document's level of compliance with the JSON standard.
2. Optional `sort_by_count` argument for [`value_counts` function](/docs/RemesPath.md#non-vectorized-functions), which sorts subarrays by count if true.

## [5.2.0] - 2023-06-04

### Added

1. [Sort form](/docs/README.md#sort-form) for sorting and shuffling arrays.
2. New [RemesPath functions](/docs/RemesPath.md#non-vectorized-functions) `rand`, `enumerate`, and `iterable`

### Changed

1. `Alt-P-J-Y` key chord no longer dumps YAML. It instead opens the [Sort form](/docs/README.md#sort-form)

### Fixed

1. Opening a tree viewer no longer sets the document's lexer language to JSON if parsing failed.

## [5.1.0] - 2023-06-02

### Added
1. The `*` multiplication operator in RemesPath now supports multiplication of strings by integers (but not integers by strings). For example, `["a", "b", "c"] * [1,2,3]` returns `["a", "bb", "ccc"]`.
2. Setting, `offer_to_show_lint` to disable the pop-up prompt that asks if the user wants to see syntax errors.
3. Menu option to open a new document with the most recently found syntax errors for the current document.
4. Dramatic improvement in speed of recursive search in RemesPath, which in turn improves the find/replace form.
5. Support for *validation* of the `exclusiveMinimum` and `exclusiveMaximum` keywords for numbers, but not random JSON generation that observes those keywords.
6. Further improvement of error messages from RemesPath queries.

### Changed
1. Whenever the user modifies a document that has an active tree viewer, a flag is set so that the document will be re-parsed the next time the user executes a query (including when the find/replace form is used).

### Fixed
1. Bug where numbers did not have their type validated correctly when using `minimum` and `maximum` keywords.