### PR TITLE
MultiReplace Bug Fix Release 1.0.3.4

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -697,10 +697,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "1.0.0.1",
+			"version": "1.0.3.4",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "51f98092bb227624cc9ed99a3c393bdcfa0ab057123152fe7d6343b436cd9a48",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/1.0.0.1/MultiReplace-v1.0.0.1-x64.zip",
+			"id": "befa019ad49c9ebe9ff851310ac809a15e85bc82fc86a2b399276c0aec5d9f12",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/1.0.3.4/MultiReplace-v1.0.3.4-x64.zip",
 			"description": "Enables multi-string replacement, storage of search/replace operations in CSV lists, export to bash scripts, and color-highlighting of different 'find words'.",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"


### PR DESCRIPTION
- Extended 'Find/Replace' fix to list operations, preventing matches being skipped. 
- Fixed sed command generation in 'Export to Bash' function, replaced slashes with delimiters.