### PR TITLE
MultiReplace Bug Fix 1.0.3.4

### DIFF
--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -782,10 +782,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "1.0.0.1",
+			"version": "1.0.3.4",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "96638a90cc7e6fc8c022f78f5bba830d7b1680c49328e44add4d35f35cb2f879",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/1.0.0.1/MultiReplace-v1.0.0.1-Win32.zip",
+			"id": "3ac959e425e6520b037e3ada94da2205a2a8ac332f8b6d743352e9de90d96d25",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/1.0.3.4/MultiReplace-v1.0.3.4-Win32.zip",
 			"description": "Enables multi-string replacement, storage of search/replace operations in CSV lists, export to bash scripts, and color-highlighting of different 'find words'.",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"


### PR DESCRIPTION
- Extended 'Find/Replace' fix to list operations, preventing matches being skipped.
- Fixed sed command generation in 'Export to Bash' function, replaced slashes with delimiters.