### PR TITLE
up JsonTools to v5.6

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -560,9 +560,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "5.4.0",
-			"id": "a516d2176fafd5702d5b8414b12049fc6cace94b69cd640b56345730476899e5",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v5.4.0/Release_x64.zip",
+			"version": "5.6.0",
+			"id": "9678e4514caa92d2466d87599a484e52944997785de15a665af5e1228fcda664",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v5.6.0/Release_x64.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, and much more",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -617,9 +617,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "5.4.0",
-			"id": "099d7a4677f5a683c56518a15ae04adc6c416d742860e74561ac65c1268ca7aa",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v5.4.0/Release_x86.zip",
+			"version": "5.6.0",
+			"id": "e19b0fbe01edaccbdc2560679f0c1bcf49cd04af8dfdc991e58760b5e0666e6f",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v5.6.0/Release_x86.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, and much more",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",


### PR DESCRIPTION
Major changes to [JsonTools](https://github.com/molsonkiko/JsonToolsNppPlugin):
1. Parse multiple selections of JSON
2. Add ability to dump selected JSON strings as raw text, dump raw text as JSON strings
3. Allow preserving of comments when pretty-printing/compressing JSON
4. Many improvements to RemesPath