### PR TITLE
Update Papyrus Script Lexer plugin to v1.2.2.351 for both x64 and x86

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1075,11 +1075,11 @@
 		{
 			"folder-name": "Papyrus",
 			"display-name": "Papyrus Script Lexer",
-			"version": "1.2.1.340",
+			"version": "1.2.2.351",
 			"npp-compatible-versions": "[8.3,]",
 			"old-versions-compatibility": "[,0.2.3.23][,8.2.1]",
-			"id": "81f158b03bfdd17c65a553ac8ab0b5b31226f557c0828236ba82cbca1d5e3556",
-			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v1.2.1/PapyrusPlugin-v1.2.1-x64.zip",
+			"id": "85fd1a37061b0ce05ca3d7f0e4357ff7b1d74211aba9f2c9c6ff857d4734c9eb",
+			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v1.2.2/PapyrusPlugin-v1.2.2-x64.zip",
 			"description": "View and edit Papyrus Script files used by Bethesda games with syntax highlighting, function and block folding, hyperlinks to referenced scripts, keywords matching, plus compilation support with anonymized output and error list view.",
 			"author": "blu3mania",
 			"homepage": "https://github.com/blu3mania/npp-papyrus"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1190,9 +1190,9 @@
 		{
 			"folder-name": "Papyrus",
 			"display-name": "Papyrus Script Lexer",
-			"version": "1.2.1.340",
-			"id": "2f2f58b564db3eb763d96a2753bf1bf2bd668ae8b0eea9ce676567b043b2c1ba",
-			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v1.2.1/PapyrusPlugin-v1.2.1-x86.zip",
+			"version": "1.2.2.351",
+			"id": "3a235bb634a72bd5d456922658b9ae0e366b7587ef6ac6a065a43a6a64b7602a",
+			"repository": "https://github.com/blu3mania/npp-papyrus/releases/download/v1.2.2/PapyrusPlugin-v1.2.2-x86.zip",
 			"description": "View and edit Papyrus Script files used by Bethesda games with syntax highlighting, function and block folding, hyperlinks to referenced scripts, keywords matching, plus compilation support with anonymized output and error list view.",
 			"author": "blu3mania",
 			"homepage": "https://github.com/blu3mania/npp-papyrus"


### PR DESCRIPTION
Release page with VirusTotal scan results: https://github.com/blu3mania/npp-papyrus/releases