### PR TITLE
Update Columns++ to 1.0.2

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -164,9 +164,9 @@
 		{
 			"folder-name": "ColumnsPlusPlus",
 			"display-name": "Columns++",
-			"version": "1.0.1",
-			"id": "934914BBD0ABE59CA185593E0018537B689321DBF0BD9F69A6B3E3C4E77C7985",
-			"repository": "https://github.com/Coises/ColumnsPlusPlus/releases/download/v1.0.1/ColumnsPlusPlus-1.0.1-x64.zip",
+			"version": "1.0.2",
+			"id": "1FDBD3C1E89AD87A841C3094FBFFDA7D7D28E4E05ACFE4B37DBB0FCBB58A425B",
+			"repository": "https://github.com/Coises/ColumnsPlusPlus/releases/download/v1.0.2/ColumnsPlusPlus-1.0.2-x64.zip",
 			"description": "Offers features for working with text and data arranged in columns, including an implementation of elastic tabstops, enhanced searching and sorting, column alignment and numeric calulations.",
 			"author": "Randall Joseph Fellmy",
 			"homepage": "https://github.com/Coises/ColumnsPlusPlus",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -160,9 +160,9 @@
 		{
 			"folder-name": "ColumnsPlusPlus",
 			"display-name": "Columns++",
-			"version": "1.0.1",
-			"id": "4345503F5C6159D4915D6E18CD1A440019771EDA000E747939BD3E05CEEFA9EA",
-			"repository": "https://github.com/Coises/ColumnsPlusPlus/releases/download/v1.0.1/ColumnsPlusPlus-1.0.1-x86.zip",
+			"version": "1.0.2",
+			"id": "91625E007608B06629AB7C462573680239EC7D497A4E8EF2775C6DDA3B50423E",
+			"repository": "https://github.com/Coises/ColumnsPlusPlus/releases/download/v1.0.2/ColumnsPlusPlus-1.0.2-x86.zip",
 			"description": "Offers features for working with text and data arranged in columns, including an implementation of elastic tabstops, enhanced searching and sorting, column alignment and numeric calulations.",
 			"author": "Randall Joseph Fellmy",
 			"homepage": "https://github.com/Coises/ColumnsPlusPlus",


### PR DESCRIPTION
Columns++ 1.0.2 fixes a serious bug in 1.0.1 that can lead to a hang (necessitating a force close of Notepad++ and consequent loss of unsaved data in all open tabs).