### PR TITLE
update JsonTools to v7.1

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -571,9 +571,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "6.1.1",
-			"id": "4904c93c5ffc44899626eab8d507678d88a9ce2353546d4b149840284f463e63",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v6.1.1/Release_x64.zip",
+			"version": "7.1",
+			"id": "28d83bab5876c3939fcfbb8973903a772f48cacff7c5a7148356152c21f90217",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v7.1.0/Release_x64.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, escaping/unescaping strings, and much more.\r\nThe tree viewer can also be used to explore CSV files and regex search results (experimental).",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -630,9 +630,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "6.1.1",
-			"id": "76664285b0781e5af6a9199f14516051052b78666a60b5927bad2e900dee91b8",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v6.1.1/Release_x86.zip",
+			"version": "7.1",
+			"id": "a606f635b4ab3005a9eb03c418be6d44e0f57155835bd8ca50ee21fe5b9cc4a8",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v7.1.0/Release_x86.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, escaping/unescaping strings, and much more.\r\nThe tree viewer can also be used to explore CSV files and regex search results (experimental).",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",


### PR DESCRIPTION
[See the changelog for all changes](https://github.com/molsonkiko/JsonToolsNppPlugin/blob/main/CHANGELOG.md#710---2024-02-28)

### Major changes:

* Add support for multiple JSON schema validation problems; validation problems are shown in the error form
* fix numerous bugs related to automatic validation and linting after editing
* major improvement to selection-based mode (earlier versions of JsonTools will have major issues with selection-based mode for Notepad++ 8.6.5 onward; this version still has problems for Notepad++ 8.6.3 and 8.6.4)
* Fix issue (in Notepad++ 8.6 onwards) where Ctrl+C and Ctrl+X could sometimes stop working in textboxes of JsonTools forms.