### PR TITLE
Up JsonTools to v7.2

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -571,9 +571,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "7.1",
-			"id": "28d83bab5876c3939fcfbb8973903a772f48cacff7c5a7148356152c21f90217",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v7.1.0/Release_x64.zip",
+			"version": "7.2",
+			"id": "883e9b2f32c18d9d2e8f8c6c4930f727cb69fa001ad48aa5cbb3d2ab0fc91ba5",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v7.2.0/Release_x64.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, escaping/unescaping strings, and much more.\r\nThe tree viewer can also be used to explore CSV files and regex search results (experimental).",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -630,9 +630,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "7.1",
-			"id": "a606f635b4ab3005a9eb03c418be6d44e0f57155835bd8ca50ee21fe5b9cc4a8",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v7.1.0/Release_x86.zip",
+			"version": "7.2",
+			"id": "7b5c115d738e9331fdd75e21dfc364ef0e45aaa3cdc772292c88e8b1b492c199",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v7.2.0/Release_x86.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, escaping/unescaping strings, and much more.\r\nThe tree viewer can also be used to explore CSV files and regex search results (experimental).",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",


### PR DESCRIPTION
## Summary

- Fixed a crash bug documented in [JsonTools issue 60](https://github.com/molsonkiko/JsonToolsNppPlugin/issues/60#issuecomment-2065419075).
- Fixed some other minor bugs and sources of irritation
- Added command to check JSON syntax (without opening tree view or reformatting document)

## [7.2.0] - 2024-04-19

### Added

1. [`Check JSON syntax now` command](/docs/README.md#check-json-syntax-now).

### Changed

1. Made it so that reloading the [error form](/docs/README.md#error-form-and-status-bar) by pressing `Enter` would not cause certain message boxes to appear, to eliminate a potential "infinite" loop where the user would hit `Enter` to close the message box, and that moved focus back to the error form, which then repeated the cycle when they lifted the `Enter` key.
2. [Automatic validation](/docs/README.md#automatically-check-for-errors-after-editing) when `auto_validate` is true no longer opens the prompt asking if user wants to open the error form (if [`offer_to_show_lint`](/docs/README.md#parser-settings) is true), because that could cause Notepad++ to crash or hang forever (see [issue 60](https://github.com/molsonkiko/JsonToolsNppPlugin/issues/60#issuecomment-2065419075)).
3. Made it so that automatic JSON schema validation (that is, any validation not manually invoked by the plugin menu command) no longer causes the caret to move to the location of the first schema validation error.
4. Automatic validation (including non-schema validation) now refreshes the error form.

### Fixed

1. Minor bug in [PPrint remembering comments](/docs/README.md#remember_comments) algorithm implementation that caused some arrays and objects to be compressed when they should have been pretty-printed.
2. Fix bug where tests could crash under some circumstances due to filesystem weirdness making it impossible to find test files.