### PR TITLE
Up JsonTools to v8.0

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -582,9 +582,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "7.2",
-			"id": "883e9b2f32c18d9d2e8f8c6c4930f727cb69fa001ad48aa5cbb3d2ab0fc91ba5",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v7.2.0/Release_x64.zip",
+			"version": "8.0",
+			"id": "a83ccdf87f9898fbb3e6ea9550a16660f7a6059b12387f8df0065f90f43635e7",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v8.0/Release_x64.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, escaping/unescaping strings, and much more.\r\nThe tree viewer can also be used to explore CSV files and regex search results (experimental).",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -630,9 +630,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "7.2",
-			"id": "7b5c115d738e9331fdd75e21dfc364ef0e45aaa3cdc772292c88e8b1b492c199",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v7.2.0/Release_x86.zip",
+			"version": "8.0",
+			"id": "024f3ae74ca5a608d45e6cabb600a271eafd92726c83d9a65ce94cc52445cc58",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v8.0/Release_x86.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, escaping/unescaping strings, and much more.\r\nThe tree viewer can also be used to explore CSV files and regex search results (experimental).",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",


### PR DESCRIPTION
# Release JsonTools v8

See [CHANGELOG](https://github.com/molsonkiko/JsonToolsNppPlugin/blob/main/CHANGELOG.md#800---2024-06-29) for full list of changes

Major changes:
- Add translation to other languages (only Italian so far)
- Improve UI of tree view
- Improve UI of `JSON from files and APIs` form
- Remove some minor settings (`max_threads_parsing`, `allow_datetimes`)