### PR TITLE
Restore Preview HTML

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1141,6 +1141,16 @@
 			"homepage": "https://github.com/npp-plugins/pork2sausage"
 		},
 		{
+			"folder-name": "PreviewHTML",
+			"display-name": "Preview HTML",
+			"version": "1.3.2.0",
+			"id": "127dbdd677b5f3f75661f06e67e4e2b35cb5e926863b6268a51c11e72a08f8ec",
+			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML64.zip%3Fname%3D%26uuid%3Dv1.3.2.0-64",
+			"description": "Preview HTML files inside Notepad++ (or in a floating window) without having to save them first.",
+			"author": "Martijn Coppoolse",
+			"homepage": "https://fossil.2of4.net/npp_preview"
+		},
+		{
 			"folder-name": "Python Indent",
 			"display-name": "Python Indent",
 			"version": "1.0.0.5",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1263,6 +1263,16 @@
 			"homepage": "https://github.com/npp-plugins/pork2sausage"
 		},
 		{
+			"folder-name": "PreviewHTML",
+			"display-name": "Preview HTML",
+			"version": "1.3.2.0",
+			"id": "b7538d5b4c61e7232ad6befe3a5eb1799544a4de741d4acd896716e9273f260b",
+			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML32.zip%3Fname%3D%26uuid%3Dv1.3.2.0-32",
+			"description": "Preview HTML files inside Notepad++ (or in a floating window) without having to save them first.",
+			"author": "Martijn Coppoolse",
+			"homepage": "https://fossil.2of4.net/npp_preview"
+		},
+		{
 			"folder-name": "PyNPP",
 			"display-name": "PyNPP",
 			"version": "1.2",

--- a/validator.py
+++ b/validator.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 import zipfile
 from hashlib import sha256
+from urllib.parse import unquote as unquote_url
 
 import requests
 from jsonschema import Draft202012Validator, FormatChecker
@@ -148,7 +149,7 @@ def parse(filename):
             print(f' *** REQUIRES Npp {req_npp_version.strip()} ***')
 
         try:
-            response = requests.get(plugin["repository"])
+            response = requests.get(unquote_url(plugin["repository"]))
         except requests.exceptions.RequestException as e:
             post_error(f'{plugin["display-name"]}: {str(e)}')
             continue


### PR DESCRIPTION
#### Problem
*Preview HTML*'s download host can't parse escaped URLs (<https://github.com/notepad-plus-plus/nppPluginList/commit/6a764d574e6220581cc20537dbdd2ed1a0392927#commitcomment-144093569>), even though it had no problem until just recently ¯&#x005C;_(ツ)_/¯

#### Fix
__*Un*__-escape download URLs in the Python script
