### PR TITLE
Update PreviewHTML repo links and id

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1144,8 +1144,8 @@
 			"folder-name": "PreviewHTML",
 			"display-name": "Preview HTML",
 			"version": "1.3.2.0",
-			"id": "127dbdd677b5f3f75661f06e67e4e2b35cb5e926863b6268a51c11e72a08f8ec",
-			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML64.zip%3Fname%3D%26uuid%3Dv1.3.2.0-64",
+			"id": "d2f500de72312abe4e22c8777e4431559025f14fd847f498701d62733bf1a06e",
+			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML.zip?uuid=release-64bits",
 			"description": "Preview HTML files inside Notepad++ (or in a floating window) without having to save them first.",
 			"author": "Martijn Coppoolse",
 			"homepage": "https://fossil.2of4.net/npp_preview"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1266,8 +1266,8 @@
 			"folder-name": "PreviewHTML",
 			"display-name": "Preview HTML",
 			"version": "1.3.2.0",
-			"id": "b7538d5b4c61e7232ad6befe3a5eb1799544a4de741d4acd896716e9273f260b",
-			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML32.zip%3Fname%3D%26uuid%3Dv1.3.2.0-32",
+			"id": "d2a616bb7b6c7c29c5efaad4faa378fa959cc0db76067c5621441b9b129e9fbb",
+			"repository": "https://fossil.2of4.net/npp_preview/zip/PreviewHTML.zip?uuid=release-32bits",
 			"description": "Preview HTML files inside Notepad++ (or in a floating window) without having to save them first.",
 			"author": "Martijn Coppoolse",
 			"homepage": "https://fossil.2of4.net/npp_preview"


### PR DESCRIPTION
- the URLs changed without notice
- the SHA256 changed without notice

(The author of the plugin has abandoned the plugin, so is not going to submit a PR with the update.  I am doing the PR, because I know there are still users of this plugin out there.)