### PR TITLE
updated MultiReplace to v3.1.2.18

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -70,10 +70,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "3.1.1.17",
+			"version": "3.1.2.18",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "99560136899d48a6d151a192be96a239d7fb438989781f34fc4cbeea5b535793",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/3.1.1.17/MultiReplace-v3.1.1.17-ARM64.zip",
+			"id": "89e2a493a651f1d20283aa352141b64652430c46bd1cbf0451609d4005397707",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/3.1.2.18/MultiReplace-v3.1.2.18-ARM64.zip",
 			"description": "Advanced multi-string replacement; storage of search/replace patterns; CSV column highlighting, targeting, and sorting; dynamic computational operations; rectangular selection support.",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -719,10 +719,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "3.1.1.17",
+			"version": "3.1.2.18",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "8cec8df70466e4383aaac8c818faefc79314db099eec181cf15900a25a524ef3",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/3.1.1.17/MultiReplace-v3.1.1.17-x64.zip",
+			"id": "9c2a453f195fdc4b394c844c8654cf7d3fa44db4b0c9a910769a86517652f335",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/3.1.2.18/MultiReplace-v3.1.2.18-x64.zip",
 			"description": "Advanced multi-string replacement; storage of search/replace patterns; CSV column highlighting, targeting, and sorting; dynamic computational operations; rectangular selection support.",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -795,10 +795,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "3.1.1.17",
+			"version": "3.1.2.18",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "a7012b81111b2c2ad91af6e1bb3c8b3ab77ce5035ed3087d3035da8c3e8f9f30",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/3.1.1.17/MultiReplace-v3.1.1.17-Win32.zip",
+			"id": "d4755cad87d2b4c1281f8fb78b36ae3ee906b88e688e56202ed714bc933083ae",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/3.1.2.18/MultiReplace-v3.1.2.18-Win32.zip",
 			"description": "Advanced multi-string replacement; storage of search/replace patterns; CSV column highlighting, targeting, and sorting; dynamic computational operations; rectangular selection support.",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"


### PR DESCRIPTION
**Implemented updates:**

- **Fixed Regex Capture Groups in 'Use Variables' Mode:** Resolved an issue where nil values in capture groups caused all subsequent groups to reset to nil, even when they had matching values.