### PR TITLE
Update AndroidLogger to fix stable issues and impl an apk manager in the file explorer

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1603,10 +1603,10 @@
 		{
 			"folder-name": "AndroidLogger",
 			"display-name": "AndroidLogger",
-			"version": "1.4.1.0",
+			"version": "1.4.1.2",
 			"npp-compatible-versions": "[7.8,]",
-			"id": "5edcf475389d6ec773dc8f15fb663d4efba68f121f0402bc16a38aa805029608",
-			"repository": "https://sourceforge.net/projects/androidlogger/files/v1.4.1/AndroidLogger.v1.4.1.0.EN.zip",
+			"id": "fcf348d24f74d2411038f46d8febf5db2c0db5ed869877ef2e1fa6c736efe51c",
+			"repository": "https://sourceforge.net/projects/androidlogger/files/v1.4.1/AndroidLogger.v1.4.1.2.EN.zip",
 			"description": "A lexer for Android, also can capture logs in real time, provides some utilities for developers.",
 			"author": "simbaba",
 			"homepage": "https://sourceforge.net/projects/androidlogger"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1603,10 +1603,10 @@
 		{
 			"folder-name": "AndroidLogger",
 			"display-name": "AndroidLogger",
-			"version": "1.4.0.5",
+			"version": "1.4.1.0",
 			"npp-compatible-versions": "[7.8,]",
-			"id": "137bdac1e84110daddd505104906ef98ed588f4a86bc279344cf204c32268a9d",
-			"repository": "https://sourceforge.net/projects/androidlogger/files/AndroidLoggerV1.4.0/AndroidLogger.v1.4.0.5.EN.zip",
+			"id": "5edcf475389d6ec773dc8f15fb663d4efba68f121f0402bc16a38aa805029608",
+			"repository": "https://sourceforge.net/projects/androidlogger/files/v1.4.1/AndroidLogger.v1.4.1.0.EN.zip",
 			"description": "A lexer for Android, also can capture logs in real time, provides some utilities for developers.",
 			"author": "simbaba",
 			"homepage": "https://sourceforge.net/projects/androidlogger"


### PR DESCRIPTION
1. Fix some stable issues, if no file selected, click to read will crash.
2. An APK manager added to the file explorer.
3. Even if no year and month also can be converted to corresponding date.
4. Refactor some codes to better performance.


<img width="954" alt="截屏2024-10-13 16 34 30" src="https://github.com/user-attachments/assets/0fe46256-d52e-4a37-abcd-239f47f7c947">
