### PR TITLE
Add plugin: pycalc

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1610,6 +1610,17 @@
 			"description": "A lexer for Android, also can capture logs in real time, provides some utilities for developers.",
 			"author": "simbaba",
 			"homepage": "https://sourceforge.net/projects/androidlogger"
+		},
+		{
+			"folder-name": "pycalc",
+			"display-name": "pycalc",
+			"version": "1.0.0",
+			"npp-compatible-versions": "[7.8.1,]",
+			"id": "b20f3ba2373aa6c6a58168370ce4b079fb88b58a60279dd316eb5b0cd00ca0e9",
+			"repository": "https://github.com/pycalc-plugin/notepad-plus-plus/releases/download/1.0.0/pycalc-x64.zip",
+			"description": "The pycalc plugin enables the execution of python code directly within the editor upon pressing the Enter key.",
+			"author": "pycalc",
+			"homepage": "https://github.com/pycalc-plugin/notepad-plus-plus"
 		}
 	]
 }

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1616,7 +1616,7 @@
 			"display-name": "pycalc",
 			"version": "1.0.0",
 			"npp-compatible-versions": "[7.8.1,]",
-			"id": "b20f3ba2373aa6c6a58168370ce4b079fb88b58a60279dd316eb5b0cd00ca0e9",
+			"id": "7708d6091754d7867f76cb5f1ff14d4aafa48ddd51da8a782b39cc8a85c921aa",
 			"repository": "https://github.com/pycalc-plugin/notepad-plus-plus/releases/download/1.0.0/pycalc-x64.zip",
 			"description": "The pycalc plugin enables the execution of python code directly within the editor upon pressing the Enter key.",
 			"author": "pycalc",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1833,6 +1833,17 @@
 			"description": "This Notepad++ plugin can hide the unsightly folding lines, and for convenience, you can fold and unfold the current level using the Alt + Left/Right keys.",
 			"author": "leonardchai@gmail.com",
 			"homepage": "https://github.com/leonardchai/FoldingLineHider"
+		},
+		{
+			"folder-name": "pycalc",
+			"display-name": "pycalc",
+			"version": "1.0.0",
+			"npp-compatible-versions": "[7.7.1,]",
+			"id": "4decd1d50b3a855221b0f98fd9d2ee201dd22c766047afe0ef4086e09a7f42bc",
+			"repository": "https://github.com/pycalc-plugin/notepad-plus-plus/releases/download/1.0.0/pycalc-x86.zip",
+			"description": "The pycalc plugin enables the execution of python code directly within the editor upon pressing the Enter key.",
+			"author": "pycalc",
+			"homepage": "https://github.com/pycalc-plugin/notepad-plus-plus"
 		}
 	]
 }


### PR DESCRIPTION
The pycalc plugin enables the execution of python code directly within the editor upon pressing the Enter key.

https://github.com/pycalc-plugin/notepad-plus-plus
