### PR TITLE
Up JsonTools to v8.3.1

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -581,9 +581,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "8.2",
-			"id": "96e80d2f691be79530cc98b668fbdb991bd746207961ad24cb5dfeb1eb8324d9",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v8.2/Release_x64.zip",
+			"version": "8.3.1",
+			"id": "b7cd4f8298285c294c9e7998ca756a2b215b77e006e81b6e37a6227e93bf51e5",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v8.3.1/Release_x64.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, escaping/unescaping strings, and much more.\r\nThe tree viewer can also be used to explore CSV files and regex search results (experimental).",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -630,9 +630,9 @@
 		{
 			"folder-name": "JsonTools",
 			"display-name": "JSON Tools",
-			"version": "8.2",
-			"id": "62c2d9989ebc37c0791be82de239619dd6b7e595126a55838cd868eaaa6002b5",
-			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v8.2/Release_x86.zip",
+			"version": "8.3.1",
+			"id": "e8066974a57e555f296c62da65a7f72c7d77243117a8d730153aec8f9a801421",
+			"repository": "https://github.com/molsonkiko/JsonToolsNppPlugin/releases/download/v8.3.1/Release_x86.zip",
 			"description": "Query/editing tool for JSON including linting, reformatting, a tree viewer with file navigation, JSON schema validation and generation, escaping/unescaping strings, and much more.\r\nThe tree viewer can also be used to explore CSV files and regex search results (experimental).",
 			"author": "Mark Johnston Olson",
 			"homepage": "https://github.com/molsonkiko/JsonToolsNppPlugin",


### PR DESCRIPTION
See changes from [v8.3](https://github.com/molsonkiko/JsonToolsNppPlugin/releases/tag/v8.3) and [v8.3.1](https://github.com/molsonkiko/JsonToolsNppPlugin/releases/tag/v8.3.1).

v8.3.1 was released so soon after v8.3 because I discovered a very easily replicated bug in v8.3 (which had actually been present since [v6.1](https://github.com/molsonkiko/JsonToolsNppPlugin/blob/main/CHANGELOG.md#610---2023-12-28) and I just hadn't dealt with it) that could cause NPP to crash, and I did not want the plugin list to have a version of JsonTools that I knew could so easily cause a crash.