### PR TITLE
Fix non-ASCII folder search issue and provides search options

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -38,10 +38,10 @@
 		{
 			"folder-name": "AndroidLogger",
 			"display-name": "AndroidLogger",
-			"version": "1.4.2.7",
+			"version": "1.4.2.8",
 			"npp-compatible-versions": "[7.8,]",
-			"id": "1842a4ec79eb78ec0719a33d43531cdfb6b80b007f6074b4ca1a92f51f034c1b",
-			"repository": "https://sourceforge.net/projects/androidlogger/files/v1.4.2/AndroidLogger.v1.4.2.7.EN.x64.zip",
+			"id": "d906cd2a19f0ee95753fe31b0281e183551bab4770e9b5e782c8ebc19eb517c9",
+			"repository": "https://sourceforge.net/projects/androidlogger/files/v1.4.2/AndroidLogger.v1.4.2.8.EN.x64.zip",
 			"description": "A lexer for Android, also can capture logs in real time, provides some utilities for developers.",
 			"author": "simbaba",
 			"homepage": "https://sourceforge.net/projects/androidlogger"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1880,10 +1880,10 @@
 		{
 			"folder-name": "AndroidLogger",
 			"display-name": "AndroidLogger",
-			"version": "1.4.2.7",
+			"version": "1.4.2.8",
 			"npp-compatible-versions": "[7.8,]",
-			"id": "359b4853942fc54f51132034ed10e02cc67eed3f6a481096cd628388d58c2446",
-			"repository": "https://sourceforge.net/projects/androidlogger/files/v1.4.2/AndroidLogger.v1.4.2.7.EN.x86.zip",
+			"id": "302a4c35dc0883ad9f5499ee012f20d4432138f87b7eae7838de2c70e329948e",
+			"repository": "https://sourceforge.net/projects/androidlogger/files/v1.4.2/AndroidLogger.v1.4.2.8.EN.x86.zip",
 			"description": "A lexer for Android, also can capture logs in real time, provides some utilities for developers.",
 			"author": "simbaba",
 			"homepage": "https://sourceforge.net/projects/androidlogger"


### PR DESCRIPTION
Replace "searchfolder" with search /f, also provides /o:opened, /r: recursive, /m: mark all, /i: ignorecase, /x:mode. The mode has the same mean with NPP search flags.

<img width="686" alt="image" src="https://github.com/user-attachments/assets/5753ea22-8722-4eef-bd4d-d43a2e2d3930" />
