### PR TITLE
Update pl.x64.json

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -125,10 +125,10 @@
 		{
 			"folder-name": "BlitzSearch",
 			"display-name": "Blitz Search",
-			"version": "1.0.0.4",
+			"version": "1.0.0.6",
 			"npp-compatible-versions": "[8.0,]",
-			"id": "edc7a40adb37068ea3c60877c88699a979aa0e7e09688483cfd2551be74f2684",
-			"repository": "https://github.com/Natestah/BlitsNppPlugin/releases/download/InitialRelease/BlitzSearch-v1.0.0.4-x64.zip",
+			"id": "323ceb8cb0d488d14866dc11ee1605298199792ad01e639c41bb177b402d6b1b",
+			"repository": "https://github.com/Natestah/BlitsNppPlugin/releases/download/v1.0.0.6/BlitzSearch-v1.0.0.6-x64.zip",
 			"description": "Adds Blitz Search This to the Toolbar. Features:\r\n- Search This command with selection to run Blitz Search with substring\r\n- Search This command with no selection to run Blitz Search with Whole word match",
 			"author": "NateStah",
 			"homepage": "https://github.com/Natestah/BlitsNppPlugin"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -125,10 +125,10 @@
 		{
 			"folder-name": "BlitzSearch",
 			"display-name": "Blitz Search",
-			"version": "1.0.0.3",
+			"version": "1.0.0.4",
 			"npp-compatible-versions": "[8.0,]",
-			"id": "f400872ac8a5383c9b9cbffac383d07cdecfbc850d652a424a3a9c593ee4c38c",
-			"repository": "https://github.com/Natestah/BlitsNppPlugin/releases/download/InitialRelease/BlitzSearch-v1.0.0.3-x64.zip",
+			"id": "edc7a40adb37068ea3c60877c88699a979aa0e7e09688483cfd2551be74f2684",
+			"repository": "https://github.com/Natestah/BlitsNppPlugin/releases/download/InitialRelease/BlitzSearch-v1.0.0.4-x64.zip",
 			"description": "Adds Blitz Search This to the Toolbar. Features:\r\n- Search This command with selection to run Blitz Search with substring\r\n- Search This command with no selection to run Blitz Search with Whole word match",
 			"author": "NateStah",
 			"homepage": "https://github.com/Natestah/BlitsNppPlugin"


### PR DESCRIPTION
updated 1.0.0.4, Blitz Search plugin with a few minor updates
-download page goto is prompted now when Blitz.exe doesn't exist
-download link is corrected
-project homepage command points to new location