### PR TITLE
Added [cmdout] feature and update icons to align Fluent UI

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -38,11 +38,11 @@
 		{
 			"folder-name": "AndroidLogger",
 			"display-name": "AndroidLogger",
-			"version": "1.4.2.8",
+			"version": "1.4.3.4",
 			"npp-compatible-versions": "[7.8,]",
-			"id": "d906cd2a19f0ee95753fe31b0281e183551bab4770e9b5e782c8ebc19eb517c9",
-			"repository": "https://sourceforge.net/projects/androidlogger/files/v1.4.2/AndroidLogger.v1.4.2.8.EN.x64.zip",
-			"description": "A lexer for Android, also can capture logs in real time, provides some utilities for developers.",
+			"id": "76d13f9d474fc3d2ebf288c732768f3e80fa668b30336e3f7493347123c492d1",
+			"repository": "https://github.com/glandon/AndroidLogger/releases/download/v1.4.3.4/AndroidLogger.v1.4.3.4.EN.x64.zip",
+			"description": "A comprehensive Android suite featuring real-time log/screen capture, integrated file explorer for rapid operations, and a smart command panel supporting one-click search/execution of commands with output retrieval.",
 			"author": "simbaba",
 			"homepage": "https://sourceforge.net/projects/androidlogger"
 		},

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1880,11 +1880,11 @@
 		{
 			"folder-name": "AndroidLogger",
 			"display-name": "AndroidLogger",
-			"version": "1.4.2.8",
+			"version": "1.4.3.4",
 			"npp-compatible-versions": "[7.8,]",
-			"id": "302a4c35dc0883ad9f5499ee012f20d4432138f87b7eae7838de2c70e329948e",
-			"repository": "https://sourceforge.net/projects/androidlogger/files/v1.4.2/AndroidLogger.v1.4.2.8.EN.x86.zip",
-			"description": "A lexer for Android, also can capture logs in real time, provides some utilities for developers.",
+			"id": "8c45c9a3540ee3bf0d487038880bb824c3150b1bd5a9156bce37f06f0f523596",
+			"repository": "https://github.com/glandon/AndroidLogger/releases/download/v1.4.3.4/AndroidLogger.v1.4.3.4.EN.x86.zip",
+			"description": "A comprehensive Android suite featuring real-time log/screen capture, integrated file explorer for rapid operations, and a smart command panel supporting one-click search/execution of commands with output retrieval.",
 			"author": "simbaba",
 			"homepage": "https://sourceforge.net/projects/androidlogger"
 		}


### PR DESCRIPTION
Added [cmdout] feature with ansi charset support, and update toolbar  icons to align with Fluent UI design standards.
```
<oscmd>
    <desc>Python Run</desc>
    <cmd>python</cmd>
    <param>@!</param>
    <type>cmdout</type>
    <charset>ansi</charset>
</oscmd>
```

<img width="1279" alt="AndroidLoggerLexer" src="https://github.com/user-attachments/assets/f1edd70f-4a5f-47d8-9764-73bc02fc1856" />
