### PR TITLE
updated MultiReplace 4.3.2.28

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -165,10 +165,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "4.3.1.27",
+			"version": "4.3.2.28",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "1d6c6d44553ce2a81948606f80adf81d5bccdfefe82f08da724a2a3dc425a8e9",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.3.1.27/MultiReplace-v4.3.1.27-ARM64.zip",
+			"id": "50e697d73d9dabb7370fcc18887b695370683ddf3bb4d04021153af43029e87b",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.3.2.28/MultiReplace-v4.3.2.28-ARM64.zip",
 			"description": "Advanced multi-string replacement; storage of search/replace patterns; CSV column highlighting, targeting, and sorting; mathematical operations on matched strings; rectangular selection support; external lookup files for data normalization and anonymization.",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -774,10 +774,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "4.3.1.27",
+			"version": "4.3.2.28",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "2ee053d0af19c35d0254b76327d1b83592f99675ed797d43ba184c526bb627d9",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.3.1.27/MultiReplace-v4.3.1.27-x64.zip",
+			"id": "e411bad0d7533bb31457a9d0475201958243c8abdcd64970c2c22039e0e3cac7",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.3.2.28/MultiReplace-v4.3.2.28-x64.zip",
 			"description": "Advanced multi-string replacement; storage of search/replace patterns; CSV column highlighting, targeting, and sorting; mathematical operations on matched strings; rectangular selection support; external lookup files for data normalization and anonymization.",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -829,10 +829,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "4.3.1.27",
+			"version": "4.3.2.28",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "817aa4b5c2b2bbec67d779ec33a665daa4d3f46ecb8e0edad529d3cb38d9fcd8",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.3.1.27/MultiReplace-v4.3.1.27-Win32.zip",
+			"id": "6ec33485258465a2c9fca94ae853f88264ccc34e9c728ee4943e71ba8cf83758",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.3.2.28/MultiReplace-v4.3.2.28-Win32.zip",
 			"description": "Advanced multi-string replacement; storage of search/replace patterns; CSV column highlighting, targeting, and sorting; mathematical operations on matched strings; rectangular selection support; external lookup files for data normalization and anonymization.",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"


### PR DESCRIPTION
## Implemented updates:

- **StayAfterReplace Option**: New setting to control cursor behavior after replacement. When enabled (`StayAfterReplace=1`), pressing *Replace* will no longer jump to the next match automatically.

- **UTF-8 Encoding for List Files**: All list files are now consistently saved in UTF-8 format for improved compatibility.

- **Encoding Fix**: Resolved encoding issue in *Find what* and *Replace with* fields when Notepad++ is running in ANSI mode.

- **Fixed Use Variables encoding**: `lkp` and `lvars` commands now handle UTF-8 and ANSI files correctly during replacement.