### PR TITLE
Fix the release workflow

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -21,6 +21,12 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
 
+    - name: Checkout main branch if push trigger is a tag
+      if: github.repository_owner == 'notepad-plus-plus' && github.ref_type == 'tag'
+      run: |
+        git fetch --all
+        git checkout master
+
     - name: Install python modules
       working-directory: .
       run: pip3 install -r requirements.txt


### PR DESCRIPTION
I guess the tag trigger event doesn't pull any branches, so there's no place to commit the updated Markdown files during the release workflow; see the [build log][0], especially:

    fatal: You are not currently on a branch.
    To push the history leading to the current (detached HEAD)
    state now, use

        git push origin HEAD:<name-of-remote-branch>

To fully validate the fix, you have to push a new tag. See [this example][1] of a successful run.

[0]: https://github.com/notepad-plus-plus/nppPluginList/actions/runs/15808507822/job/44557433314
[1]: https://github.com/rdipardo/nppPluginList/actions/runs/15810375703/job/44560889314


