### PR TITLE
updated MultiReplace 4.5.1.31

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -165,10 +165,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "4.5.0.30",
+			"version": "4.5.1.31",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "76eca0f53bafe685b75dcbc093078ab880e39e7a34749e631007667bfcb9da42",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.5.0.30/MultiReplace-v4.5.0.30-ARM64.zip",
+			"id": "c9ec9fdd2b714aef9728665be8c98eff637237ae666dd481a871817db165281e",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.5.1.31/MultiReplace-v4.5.1.31-ARM64.zip",
 			"description": "Multi-string replacement across single or multiple files; reusable search/replace lists; CSV column operations (targeting, sort, delete, replace); external lookup tables; rectangular selection support; conditional (if/then) and math logic.\r\n",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -774,10 +774,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "4.5.0.30",
+			"version": "4.5.1.31",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "26cf490f7849fbc930907f64919548f0c5b0183559551f83b48356aa96a3f3d4",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.5.0.30/MultiReplace-v4.5.0.30-x64.zip",
+			"id": "4b1cee81b9ce76aad667e214701eefc43b358c4743fd6ad0489dfb8a37acbc15",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.5.1.31/MultiReplace-v4.5.1.31-x64.zip",
 			"description": "Multi-string replacement across single or multiple files; reusable search/replace lists; CSV column operations (targeting, sort, delete, replace); external lookup tables; rectangular selection support; conditional (if/then) and math logic.\r\n",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -829,10 +829,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "4.5.0.30",
+			"version": "4.5.1.31",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "5217e67cab72f08c21bffd8cc8d478c080f18fb18e7c7b372b7cb7a859c4442d",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.5.0.30/MultiReplace-v4.5.0.30-Win32.zip",
+			"id": "e7e0454a6924601f7ca0d5b149ce6b4cfed1fb356bbd25d1849b19f19f95284f",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.5.1.31/MultiReplace-v4.5.1.31-Win32.zip",
 			"description": "Multi-string replacement across single or multiple files; reusable search/replace lists; CSV column operations (targeting, sort, delete, replace); external lookup tables; rectangular selection support; conditional (if/then) and math logic.\r\n",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"


### PR DESCRIPTION
- **AllFromCursor Option:** New setting to control the start position of “Find All”, “Replace All”, and “Mark”. When enabled (AllFromCursor=1), these actions begin at the current cursor position instead of the document start. With **Wrap Around** enabled, they always cover the entire file.
