### PR TITLE
Update to CollectionInterface 1.3.0

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -26,9 +26,9 @@
 		{
 			"folder-name": "CollectionInterface",
 			"display-name": "CollectionInterface",
-			"version": "1.2.0",
-			"id": "2037db755933565963e6167505ac3a8c700fc0d1a1e600f7c3e7b51e069b0be2",
-			"repository": "https://github.com/pryrt/NppPlugin-CollectionInterface/releases/download/v1.2.0/CollectionInterface_v1.2.0_ARM64.zip",
+			"version": "1.3.0",
+			"id": "c3722ac2933aee3183d819200f2510539b51768e9eaa2e37f71abd12b0de9df2",
+			"repository": "https://github.com/pryrt/NppPlugin-CollectionInterface/releases/download/v1.3.0/CollectionInterface_v1.3.0_ARM64.zip",
 			"description": "Interface to the official UserDefinedLanguage Collection and nppThemes Collection.\r\n\r\nAllows easy download and installation of a UDL (with FunctionList and AutoCompletion definitions, when available) or a Theme",
 			"author": "pryrt",
 			"homepage": "https://github.com/pryrt/NppPlugin-CollectionInterface",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -186,9 +186,9 @@
 		{
 			"folder-name": "CollectionInterface",
 			"display-name": "CollectionInterface",
-			"version": "1.2.0",
-			"id": "329d43febc698b0afd31062a10d97d4b36d770ff20af95c431ffb244e36c0b47",
-			"repository": "https://github.com/pryrt/NppPlugin-CollectionInterface/releases/download/v1.2.0/CollectionInterface_v1.2.0_x64.zip",
+			"version": "1.3.0",
+			"id": "ca02cc609c41a9732f8729f4414a7c334502cc5593fec1fe3aaf942e86caaca3",
+			"repository": "https://github.com/pryrt/NppPlugin-CollectionInterface/releases/download/v1.3.0/CollectionInterface_v1.3.0_x64.zip",
 			"description": "Interface to the official UserDefinedLanguage Collection and nppThemes Collection.\r\n\r\nAllows easy download and installation of a UDL (with FunctionList and AutoCompletion definitions, when available) or a Theme",
 			"author": "pryrt",
 			"homepage": "https://github.com/pryrt/NppPlugin-CollectionInterface",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -160,9 +160,9 @@
 		{
 			"folder-name": "CollectionInterface",
 			"display-name": "CollectionInterface",
-			"version": "1.2.0",
-			"id": "0aebadc4d6f13ddc2e9ef6cdc5f7225092eca4dbd56e50b0fb6b65b3db71074b",
-			"repository": "https://github.com/pryrt/NppPlugin-CollectionInterface/releases/download/v1.2.0/CollectionInterface_v1.2.0_Win32.zip",
+			"version": "1.3.0",
+			"id": "592711eeb009ed3603f13d0cc88d75e0e2eb65cb520c9f1e57505ff5bfb364fc",
+			"repository": "https://github.com/pryrt/NppPlugin-CollectionInterface/releases/download/v1.3.0/CollectionInterface_v1.3.0_Win32.zip",
 			"description": "Interface to the official UserDefinedLanguage Collection and nppThemes Collection.\r\n\r\nAllows easy download and installation of a UDL (with FunctionList and AutoCompletion definitions, when available) or a Theme",
 			"author": "pryrt",
 			"homepage": "https://github.com/pryrt/NppPlugin-CollectionInterface",


### PR DESCRIPTION
allows plugin to update overrideMap for UDL FunctionLists