### PR TITLE
updated MultiReplace 4.6.0.33

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -165,10 +165,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "4.5.2.32",
+			"version": "4.6.0.33",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "e405e6c61637097e51236e18b76217506d82b02410a910894fc190a3b352c3e6",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.5.2.32/MultiReplace-v4.5.2.32-ARM64.zip",
+			"id": "ff398ff2f6b8951ec3999339e6592792bf772bd6fad46dcfc74963f84848fdb4",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.6.0.33/MultiReplace-v4.6.0.33-ARM64.zip",
 			"description": "Multi-string replacement across single or multiple files; reusable search/replace lists; CSV column operations (targeting, sort, delete, replace); external lookup tables; rectangular selection support; conditional (if/then) and math logic.\r\n",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -774,10 +774,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "4.5.2.32",
+			"version": "4.6.0.33",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "2c7f5ed69d5017a7d87909a51470bedf16a51e77f04ea68a189b0e53213cee44",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.5.2.32/MultiReplace-v4.5.2.32-x64.zip",
+			"id": "a9aed5a5a96c7e33df21a9ad068c27f408d86284734444517630f74e0e058f8a",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.6.0.33/MultiReplace-v4.6.0.33-x64.zip",
 			"description": "Multi-string replacement across single or multiple files; reusable search/replace lists; CSV column operations (targeting, sort, delete, replace); external lookup tables; rectangular selection support; conditional (if/then) and math logic.\r\n",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -829,10 +829,10 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "4.5.2.32",
+			"version": "4.6.0.33",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "16ae99bdd9202173163ba3f5eba09973b3ea2a651fb1556781a517c7157d27dd",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.5.2.32/MultiReplace-v4.5.2.32-Win32.zip",
+			"id": "d543462179ee2a4eccb1df7b476d7738b1025baec6ac68c21a566534850129bb",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/4.6.0.33/MultiReplace-v4.6.0.33-Win32.zip",
 			"description": "Multi-string replacement across single or multiple files; reusable search/replace lists; CSV column operations (targeting, sort, delete, replace); external lookup tables; rectangular selection support; conditional (if/then) and math logic.\r\n",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"


### PR DESCRIPTION
**Implemented updates:**

- **Float Tab**: Added a Float Tab button in the result window to align tab and non-tab-delimited columns, with numeric values right-aligned.

- **CJK Encoding Fix**: Find in Files now correctly recognizes and processes Chinese, Japanese, and Korean encoded files.

- **Result Navigation Fix**: Double-clicking results in the result window now jumps directly to the matched position on the first open.

- **Binary Display Fix**: Improved display of binary and non-text data in the result window for better readability.

- **Memory Cleanup Fix**: Corrected memory handling during repeated Find in Files operations.