### PR TITLE
ConfigUpdater Plugin v2.4.0

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -49,9 +49,9 @@
 		{
 			"folder-name": "ConfigUpdater",
 			"display-name": "ConfigUpdater",
-			"version": "2.3.0",
-			"id": "1ae55100c090e353f039634dc7d28be52489dce7a742da383b37a8f3a513bbe2",
-			"repository": "https://github.com/pryrt/NppPlugin-ConfigUpdater/releases/download/v2.3.0/ConfigUpdater_v2.3.0_ARM64.zip",
+			"version": "2.4.0",
+			"id": "237cce133896c7252886e762251d7aab21e451629200d1e3a8dbd7b3267305bd",
+			"repository": "https://github.com/pryrt/NppPlugin-ConfigUpdater/releases/download/v2.4.0/ConfigUpdater_v2.4.0_ARM64.zip",
 			"description": "Notepad++ Plugin to keep Langs/Stylers/Themes config files up-to-date",
 			"author": "pryrt",
 			"homepage": "https://github.com/pryrt/NppPlugin-ConfigUpdater",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -276,9 +276,9 @@
 		{
 			"folder-name": "ConfigUpdater",
 			"display-name": "ConfigUpdater",
-			"version": "2.3.0",
-			"id": "c0fa5dcc4ca56852a503923c0e9fc2e5e5582fd7eb26735e439298500d4c55d6",
-			"repository": "https://github.com/pryrt/NppPlugin-ConfigUpdater/releases/download/v2.3.0/ConfigUpdater_v2.3.0_x64.zip",
+			"version": "2.4.0",
+			"id": "8c889ad278591fa50b4053848b3060115db38fc24e17ed6ca0b83c47664faab0",
+			"repository": "https://github.com/pryrt/NppPlugin-ConfigUpdater/releases/download/v2.4.0/ConfigUpdater_v2.4.0_x64.zip",
 			"description": "Notepad++ Plugin to keep Langs/Stylers/Themes config files up-to-date",
 			"author": "pryrt",
 			"homepage": "https://github.com/pryrt/NppPlugin-ConfigUpdater",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -235,9 +235,9 @@
 		{
 			"folder-name": "ConfigUpdater",
 			"display-name": "ConfigUpdater",
-			"version": "2.3.0",
-			"id": "a0a0d985abd14dd429a9bbba05f8b117f7492f390d8716e9c57b3113107b79b7",
-			"repository": "https://github.com/pryrt/NppPlugin-ConfigUpdater/releases/download/v2.3.0/ConfigUpdater_v2.3.0_Win32.zip",
+			"version": "2.4.0",
+			"id": "5a3f5af5492051876f8f7f7087bce351f5f37a6e1b6b2b63e2a360a1d1805034",
+			"repository": "https://github.com/pryrt/NppPlugin-ConfigUpdater/releases/download/v2.4.0/ConfigUpdater_v2.4.0_Win32.zip",
 			"description": "Notepad++ Plugin to keep Langs/Stylers/Themes config files up-to-date",
 			"author": "pryrt",
 			"homepage": "https://github.com/pryrt/NppPlugin-ConfigUpdater",


### PR DESCRIPTION
Add ability to Update Validators (XSD files)
Also, the default XSD has been updated to allow optional `modelDate` attribute (to work with N++ v8.8.9).