### PR TITLE
Remove obsolete plugin ConfigUpdater

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -47,17 +47,6 @@
 			"homepage": "https://github.com/pnedev/comparePlus"
 		},
 		{
-			"folder-name": "ConfigUpdater",
-			"display-name": "ConfigUpdater",
-			"version": "2.4.0",
-			"id": "237cce133896c7252886e762251d7aab21e451629200d1e3a8dbd7b3267305bd",
-			"repository": "https://github.com/pryrt/NppPlugin-ConfigUpdater/releases/download/v2.4.0/ConfigUpdater_v2.4.0_ARM64.zip",
-			"description": "Notepad++ Plugin to keep Langs/Stylers/Themes config files up-to-date",
-			"author": "pryrt",
-			"homepage": "https://github.com/pryrt/NppPlugin-ConfigUpdater",
-			"npp-compatible-versions": "[8.8.1,]"
-		},
-		{
 			"folder-name": "FWDataViz",
 			"display-name": "Fixed-width Data Visualizer",
 			"version": "2.6.7.0",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -274,17 +274,6 @@
 			"npp-compatible-versions": "[8.5.4,]"
 		},
 		{
-			"folder-name": "ConfigUpdater",
-			"display-name": "ConfigUpdater",
-			"version": "2.4.0",
-			"id": "8c889ad278591fa50b4053848b3060115db38fc24e17ed6ca0b83c47664faab0",
-			"repository": "https://github.com/pryrt/NppPlugin-ConfigUpdater/releases/download/v2.4.0/ConfigUpdater_v2.4.0_x64.zip",
-			"description": "Notepad++ Plugin to keep Langs/Stylers/Themes config files up-to-date",
-			"author": "pryrt",
-			"homepage": "https://github.com/pryrt/NppPlugin-ConfigUpdater",
-			"npp-compatible-versions": "[8.8.1,]"
-		},
-		{
 			"folder-name": "CSScriptNpp",
 			"display-name": "CS-Script - C# Intellisense",
 			"version": "2.0.11.0",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -233,17 +233,6 @@
 			"npp-compatible-versions": "[8.5.4,]"
 		},
 		{
-			"folder-name": "ConfigUpdater",
-			"display-name": "ConfigUpdater",
-			"version": "2.4.0",
-			"id": "5a3f5af5492051876f8f7f7087bce351f5f37a6e1b6b2b63e2a360a1d1805034",
-			"repository": "https://github.com/pryrt/NppPlugin-ConfigUpdater/releases/download/v2.4.0/ConfigUpdater_v2.4.0_Win32.zip",
-			"description": "Notepad++ Plugin to keep Langs/Stylers/Themes config files up-to-date",
-			"author": "pryrt",
-			"homepage": "https://github.com/pryrt/NppPlugin-ConfigUpdater",
-			"npp-compatible-versions": "[8.8.1,]"
-		},
-		{
 			"folder-name": "CSScriptNpp",
 			"display-name": "CS-Script - C# Intellisense",
 			"version": "2.0.11.0",


### PR DESCRIPTION
Notepad++ v8.9's automatic config updates mean the plugin shouldn't be needed by normal users (so doesn't need to be in Plugins Admin)