### PR TITLE
update AnotherMarkdown to 0.1.6

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -49,10 +49,10 @@
 		{
 			"folder-name": "AnotherMarkdown",
 			"display-name": "Another Markdown",
-			"version": "0.1.4",
-			"id": "95453e9257b8ac1bb89fbc465625382828440b57df2691d6967654d9f96621fc",
-			"repository": "https://github.com/ezyuzin/NppAnotherMarkdown/releases/download/0.1.4/AnotherMarkdown-0.1.4-x64.zip",
-			"description": "[Requires .NET framework v4.7.2]\r\nEasiest customizable, extendable preview and edit for Markdown files.\r\nBonus: Edit and preview 360 photos",
+			"version": "0.1.6",
+			"id": "5964887dec3528e2d6027b150395d4677f0f9fc18e8e2e935d64a2e3c84e5fc4",
+			"repository": "https://github.com/ezyuzin/NppAnotherMarkdown/releases/download/0.1.6/AnotherMarkdown-0.1.6-x64.zip",
+			"description": "[Requires .NET framework v4.7.2]\r\nEasiest customizable, extendable preview and edit for Markdown files",
 			"author": "Evgeny Zyuzin",
 			"homepage": "https://github.com/ezyuzin/NppAnotherMarkdown",
 			"npp-compatible-versions": "[8.5,]"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -47,10 +47,10 @@
 		{
 			"folder-name": "AnotherMarkdown",
 			"display-name": "Another Markdown",
-			"version": "0.1.4",
-			"id": "aabf3110228b2ce7415b7fbee6657366937b97530f6d2207703b6c78ae63e741",
-			"repository": "https://github.com/ezyuzin/NppAnotherMarkdown/releases/download/0.1.4/AnotherMarkdown-0.1.4-x86.zip",
-			"description": "[Requires .NET framework v4.7.2]\r\nEasiest customizable, extendable preview and edit for Markdown files.\r\nBonus: Edit and preview 360 photos",
+			"version": "0.1.6",
+			"id": "58f030480fa88bf74dc5e60cb30df41b6dc8ed68d31d77658b3cbff24b2b09f1",
+			"repository": "https://github.com/ezyuzin/NppAnotherMarkdown/releases/download/0.1.6/AnotherMarkdown-0.1.6-x86.zip",
+			"description": "[Requires .NET framework v4.7.2]\r\nEasiest customizable, extendable preview and edit for Markdown files",
 			"author": "Evgeny Zyuzin",
 			"homepage": "https://github.com/ezyuzin/NppAnotherMarkdown",
 			"npp-compatible-versions": "[8.5,]"


### PR DESCRIPTION
- Markdown Plugin Pack added
- highlight.js: code syntax highlight plugin added. Enable it via settings  
- Support drag-and-drop and CTRL+V insert images into markdown preview.  
Markup `![](image path)` inserted into current cursor position. 
Image naming is starts from 010.ext and incrementing with step 5, ie 010.jpg 015.jpg, 020.jpg, and each image stored in folder "./img" where markdown document located.  
Location can be changed by edit [assets/markdown/markdown.js]().

- Added navigation over existing Markdown files when clicking a link to such a file in the preview window; previous behavior: such navigation was ignored.
- Preserve preview position after switch between documents
- fix: with async webview initialization
- fix: undocking the main (preview) window freezes NPP++ if user click link to another markdown document and navigate it (open file in npp)
