### PR TITLE
Update sort_plugin_lists.ps1

### DIFF
--- a/sort_plugin_lists.ps1
+++ b/sort_plugin_lists.ps1
@@ -1,10 +1,8 @@
 function Sort-Json($file)
 {
-    $a = Get-Content $file | ConvertFrom-Json
-    $a.'npp-plugins' = $a.'npp-plugins' | sort -Property 'display-name'
-    $a | ConvertTo-Json > $file
-    #replace 2 spaces by tab
-    $content = [IO.File]::ReadAllText($file)
+    $a = Get-Content $file -Raw | ConvertFrom-Json
+    $a.'npp-plugins' = $a.'npp-plugins' | Sort-Object -Property 'display-name'
+    $content = $a | ConvertTo-Json -Depth 10
     $content = $content -replace ' {2}', "`t"
     [IO.File]::WriteAllText($file, $content)
 }
@@ -12,4 +10,3 @@ function Sort-Json($file)
 Sort-Json ".\src\pl.x64.json"
 Sort-Json ".\src\pl.x86.json"
 Sort-Json ".\src\pl.arm64.json"
-


### PR DESCRIPTION
Pull Request: Fix sort_plugin_lists.ps1 script

Summary
Fix `ConvertTo-Json` depth issue that would corrupt plugin data when running the sort script.
The current script uses `ConvertTo-Json` without specifying `-Depth`. PowerShell defaults to depth 2, but the plugin objects in the JSON files are at depth 3. This causes plugin properties to be truncated to type names like `System.Object[]` instead of their actual values.
 Changes
1. Added `-Depth 10` to `ConvertTo-Json` to preserve all nested data
2. Added `-Raw` to `Get-Content` for more reliable JSON parsing
3. Removed redundant file write operation (was writing twice)

Before::
```powershell
$a = Get-Content $file | ConvertFrom-Json
$a.'npp-plugins' = $a.'npp-plugins' | sort -Property 'display-name'
$a | ConvertTo-Json > $file
$content = [IO.File]::ReadAllText($file)
$content = $content -replace ' {2}', "`t"
[IO.File]::WriteAllText($file, $content)
```

**After**
```powershell
$a = Get-Content $file -Raw | ConvertFrom-Json
$a.'npp-plugins' = $a.'npp-plugins' | Sort-Object -Property 'display-name'
$content = $a | ConvertTo-Json -Depth 10
$content = $content -replace ' {2}', "`t"
[IO.File]::WriteAllText($file, $content)
```

--Testing--
Verified that the JSON structure (max depth 4) is fully preserved after sorting.