### PR TITLE
Add HLASMLexer - Column-aware HLASM syntax highlighting

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -595,7 +595,7 @@
 		{
 			"folder-name": "HLASMLexer",
 			"display-name": "HLASM Lexer - Column-Aware Syntax Highlighting",
-			"version": "1.0.1",
+			"version": "1.0.0",
 			"id": "4bf87ca7aed8d068169d588d1ac791ee10fadef5f1f5a566915d5990440fec95",
 			"repository": "https://github.com/Zaneham/hlasm-npp/releases/download/v1.0.1/HLASMLexer_x64.zip",
 			"description": "Column-aware syntax highlighting for IBM HLASM. Understands the 80-column punch card layout — labels, operations, operands, continuation markers and sequence numbers are each highlighted by their column position, not just keywords.",


### PR DESCRIPTION
Plugin: [hlasm-npp](https://github.com/Zaneham/hlasm-npp)

Column-aware syntax highlighting for IBM High Level Assembler, for us lovely mainframe folk. Highlights labels, operations, operands, continuation markers and sequence numbers by their column position (the 80-column punch card layout), not just by keywords.

- Release: https://github.com/Zaneham/hlasm-npp/releases/tag/v1.0.0
- x64 only
- Tested on Notepad++ 8.x