### PR TITLE
Update NppTreeSitter to 1.1.0

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -487,7 +487,7 @@
 			"folder-name": "TreeSitterLexer",
 			"display-name": "TreeSitter",
 			"version": "1.1.0",
-			"id": "f26ed143aefef0d2cdf183ef8dc830e8c6b490c01a7b6143c43c3378eb5bc1e3",
+			"id": "49A37ED0D3C4A9CEAD489D06EDB4B86F5C87BDA4AFD53A5D935240CC50B7F7B0",
 			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.1.0/NppTreeSitter-arm64.zip",
 			"description": "Integrate Tree-sitter to Notepad++. AST-based syntax highlighting and code folding for many languages.",
 			"author": "Tuomas Hietanen",

--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -486,9 +486,9 @@
 		{
 			"folder-name": "TreeSitterLexer",
 			"display-name": "TreeSitter",
-			"version": "1.0.0",
-			"id": "abdc416e92deeae68207e03f2b8da04378a1788e0996811c23d14758202d7df1",
-			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.0.0/NppTreeSitter-arm64.zip",
+			"version": "1.1.0",
+			"id": "72db590afb1b5fea04e2140dbf610081c9c2a962f0f1ff8fc0b4a205984ce756",
+			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.1.0/NppTreeSitter-arm64.zip",
 			"description": "Integrate Tree-sitter to Notepad++. AST-based syntax highlighting and code folding for many languages.",
 			"author": "Tuomas Hietanen",
 			"homepage": "https://github.com/Thorium/NppTreeSitter/"

--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -487,7 +487,7 @@
 			"folder-name": "TreeSitterLexer",
 			"display-name": "TreeSitter",
 			"version": "1.1.0",
-			"id": "72db590afb1b5fea04e2140dbf610081c9c2a962f0f1ff8fc0b4a205984ce756",
+			"id": "f26ed143aefef0d2cdf183ef8dc830e8c6b490c01a7b6143c43c3378eb5bc1e3",
 			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.1.0/NppTreeSitter-arm64.zip",
 			"description": "Integrate Tree-sitter to Notepad++. AST-based syntax highlighting and code folding for many languages.",
 			"author": "Tuomas Hietanen",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1754,9 +1754,9 @@
 		{
 			"folder-name": "TreeSitterLexer",
 			"display-name": "TreeSitter",
-			"version": "1.0.0",
-			"id": "93e4214d9360fe4e9fd3be4dfc1e2a2869ea5a1c9fdb64e1662a2f5effd36c52",
-			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.0.0/NppTreeSitter-x64.zip",
+			"version": "1.1.0",
+			"id": "9e78fa3a701e6809dbeabcabc13d574021e1930dc775a6e0d601e942caf8574c",
+			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.1.0/NppTreeSitter-x64.zip",
 			"description": "Integrate Tree-sitter to Notepad++. AST-based syntax highlighting and code folding for many languages.",
 			"author": "Tuomas Hietanen",
 			"homepage": "https://github.com/Thorium/NppTreeSitter/"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1755,7 +1755,7 @@
 			"folder-name": "TreeSitterLexer",
 			"display-name": "TreeSitter",
 			"version": "1.1.0",
-			"id": "9e78fa3a701e6809dbeabcabc13d574021e1930dc775a6e0d601e942caf8574c",
+			"id": "bfba5488732f9eab7d91ef4786310c0f3cfd684617b9250045934b695ca83d3c",
 			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.1.0/NppTreeSitter-x64.zip",
 			"description": "Integrate Tree-sitter to Notepad++. AST-based syntax highlighting and code folding for many languages.",
 			"author": "Tuomas Hietanen",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1755,7 +1755,7 @@
 			"folder-name": "TreeSitterLexer",
 			"display-name": "TreeSitter",
 			"version": "1.1.0",
-			"id": "bfba5488732f9eab7d91ef4786310c0f3cfd684617b9250045934b695ca83d3c",
+			"id": "DC077FE10BEAC90FD9AF517E864EB80821DBFA3A46753C650170062786D12F00",
 			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.1.0/NppTreeSitter-x64.zip",
 			"description": "Integrate Tree-sitter to Notepad++. AST-based syntax highlighting and code folding for many languages.",
 			"author": "Tuomas Hietanen",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1881,7 +1881,7 @@
 			"folder-name": "TreeSitterLexer",
 			"display-name": "TreeSitter",
 			"version": "1.1.0",
-			"id": "9387c7fc2860de0ea03ce62e80d2098ec9252638d804e7dd310605731024df6a",
+			"id": "e0aced961ee94a8bc5bed78e4366d07f3105ac7d09c2fb551c8a974ead94574e",
 			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.1.0/NppTreeSitter-x86.zip",
 			"description": "Integrate Tree-sitter to Notepad++. AST-based syntax highlighting and code folding for many languages.",
 			"author": "Tuomas Hietanen",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1880,9 +1880,9 @@
 		{
 			"folder-name": "TreeSitterLexer",
 			"display-name": "TreeSitter",
-			"version": "1.0.0",
-			"id": "27edd5e8c21e35748b3a1d6faf5f1bb98a5f893ba6c488b6a15d98eedc98eafe",
-			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.0.0/NppTreeSitter-x86.zip",
+			"version": "1.1.0",
+			"id": "9387c7fc2860de0ea03ce62e80d2098ec9252638d804e7dd310605731024df6a",
+			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.1.0/NppTreeSitter-x86.zip",
 			"description": "Integrate Tree-sitter to Notepad++. AST-based syntax highlighting and code folding for many languages.",
 			"author": "Tuomas Hietanen",
 			"homepage": "https://github.com/Thorium/NppTreeSitter/"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1881,7 +1881,7 @@
 			"folder-name": "TreeSitterLexer",
 			"display-name": "TreeSitter",
 			"version": "1.1.0",
-			"id": "e0aced961ee94a8bc5bed78e4366d07f3105ac7d09c2fb551c8a974ead94574e",
+			"id": "C8E3B4613799819C1FFE23942BD607E26788EE60AFF9A58C77778DA8EE8A087E",
 			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.1.0/NppTreeSitter-x86.zip",
 			"description": "Integrate Tree-sitter to Notepad++. AST-based syntax highlighting and code folding for many languages.",
 			"author": "Tuomas Hietanen",


### PR DESCRIPTION
## Summary
- update the x64, x86, and arm64 TreeSitterLexer entries to the 1.1.0 release assets
- refresh the plugin list SHA-256 ids for all three architectures
- keep the existing plugin metadata unchanged apart from the versioned release artifact references

## Notes
- local validation is currently blocked by an existing alidator.py path issue in this checkout: it writes extracted DLLs under paths like ./x64 /..., which fails before reaching the updated entry
- the release assets referenced here are already published and their hashes were taken from the packaged 1.1.0 artifacts
