### PR TITLE
Add VirtualTabGroups (x64, x86)

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1794,6 +1794,16 @@
 			"homepage": "https://github.com/FatihC/VirtualFolders"
 		},
 		{
+			"folder-name": "VirtualTabGroups",
+			"display-name": "Virtual Tab Groups",
+			"version": "1.0.0",
+			"id": "78e869ba856192017bfb0ef06fa55af9efb0e545ecb20032efb4ef8f38063713",
+			"repository": "https://github.com/JamesShaver/VirtualTabGroups/releases/download/v1.0.0/VirtualTabGroups_x64.zip",
+			"description": "Dockable panel that organizes open documents into virtual folders. Group files into custom hierarchies independent of disk layout — folder structure, panel visibility, and unsaved-buffer references all persist across Notepad++ sessions. Supports drag-and-drop, multi-select, file aliasing, and dark mode.",
+			"author": "James Shaver",
+			"homepage": "https://github.com/JamesShaver/VirtualTabGroups"
+		},
+		{
 			"folder-name": "VisualStudioLineCopy",
 			"display-name": "Visual Studio Line Copy",
 			"version": "1.0.0.2",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1920,6 +1920,16 @@
 			"homepage": "https://github.com/FatihC/VirtualFolders"
 		},
 		{
+			"folder-name": "VirtualTabGroups",
+			"display-name": "Virtual Tab Groups",
+			"version": "1.0.0",
+			"id": "6944348826f8e31f6b7fa9c0ef0ace7cc2f5527b0c48bb76915951eb8f2e83e6",
+			"repository": "https://github.com/JamesShaver/VirtualTabGroups/releases/download/v1.0.0/VirtualTabGroups_x86.zip",
+			"description": "Dockable panel that organizes open documents into virtual folders. Group files into custom hierarchies independent of disk layout — folder structure, panel visibility, and unsaved-buffer references all persist across Notepad++ sessions. Supports drag-and-drop, multi-select, file aliasing, and dark mode.",
+			"author": "James Shaver",
+			"homepage": "https://github.com/JamesShaver/VirtualTabGroups"
+		},
+		{
 			"folder-name": "VisualStudioLineCopy",
 			"display-name": "Visual Studio Line Copy",
 			"version": "1.0.0.2",


### PR DESCRIPTION
## Plugin

**Virtual Tab Groups** — a dockable panel that organizes open documents into virtual folders that persist across sessions.

- Repository: https://github.com/JamesShaver/VirtualTabGroups
- Release: https://github.com/JamesShaver/VirtualTabGroups/releases/tag/v1.0.0
- Author: James Shaver

## Submission checklist

- [x] `folder-name` matches the shipped DLL (`VirtualTabGroups.dll`).
- [x] `display-name`, `version`, `id`, `repository`, `description`, `author`, `homepage` populated per schema.
- [x] DLL `FileVersion` is `1.0.0.0`, matching the schema-padded version.
- [x] Both `pl.x64.json` and `pl.x86.json` updated with architecture-specific zip URLs and SHA-256 hashes computed from the published GitHub release assets.
- [x] Entry inserted in case-insensitive `folder-name` order (between `VirtualFolders` and `VisualStudioLineCopy`).
- [x] CRLF line endings preserved; no other content modified.
- [ ] ARM64 intentionally omitted — the IL post-processor used to produce unmanaged exports (3F.DllExport 1.7.4) doesn't recognize ARM64 as a cpu platform target. ARM64 entry can be added in a follow-up once upstream support lands.

## Hashes

- VirtualTabGroups_x64.zip: `78e869ba856192017bfb0ef06fa55af9efb0e545ecb20032efb4ef8f38063713`
- VirtualTabGroups_x86.zip: `6944348826f8e31f6b7fa9c0ef0ace7cc2f5527b0c48bb76915951eb8f2e83e6`