### PR TITLE
Add Bunyan Log Viewer to x64 plugin list

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -149,7 +149,7 @@
 			"display-name": "Bunyan Log Viewer",
 			"version": "1.0.0",
 			"id": "CB3D00E6D3B99970CAFE07ECF4DC954B27423DD7A6F7419D8AD2A46724FA2330",
-			"repository": "https://raw.githubusercontent.com/jayapalb/nppPluginList/master/assets/BunyanLogViewer_x64.zip",
+			"repository": "https://github.com/jayapalb/notepad-bunyan-plugin/releases/download/1.0.0/BunyanLogViewer_x64.zip",
 			"description": "Docked Bunyan log viewer for Notepad++ with Bunyan-style short formatting, in-pane search, and inline DEBUG/INFO/WARN/ERROR filters.",
 			"author": "Jayapal B",
 			"homepage": "https://github.com/jayapalb/nodepaddplus_bunyan-plugin"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -149,7 +149,7 @@
 			"display-name": "Bunyan Log Viewer",
 			"version": "1.0.0",
 			"id": "CB3D00E6D3B99970CAFE07ECF4DC954B27423DD7A6F7419D8AD2A46724FA2330",
-			"repository": "https://github.com/jayapalb/nodepaddplus_bunyan-plugin/releases/download/v1.0.0/BunyanLogViewer_x64.zip",
+			"repository": "https://raw.githubusercontent.com/jayapalb/nppPluginList/master/assets/BunyanLogViewer_x64.zip",
 			"description": "Docked Bunyan log viewer for Notepad++ with Bunyan-style short formatting, in-pane search, and inline DEBUG/INFO/WARN/ERROR filters.",
 			"author": "Jayapal B",
 			"homepage": "https://github.com/jayapalb/nodepaddplus_bunyan-plugin"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1897,16 +1897,6 @@
 			"description": "Small set of useful tools for editing XML. Plugin is MSXML-based. The features are:\r\n- XML syntax Check\r\n- XML Schema (XSD) + DTD Validation\r\n- XML tag autoclose\r\n- Pretty print\n- Linarize XML\r\n- Current XML Path\r\n- Conversion XML &amp;lt;-&amp;gt; Text\n- Comment / Uncomment\r\n- XPath expression evaluation",
 			"author": "Nicolas Crittin",
 			"homepage": "https://github.com/morbac/xmltools"
-		},
-		{
-			"folder-name": "zoomdisabler_x64",
-			"display-name": "Zoom Disabler",
-			"version": "1.2.0",
-			"id": "eb49c4fce581fa63b024a3a0454ccc49d082b9524c0cc9a0d5c25544e264da55",
-			"repository": "https://github.com/StanDog/npp-zoomdisabler/raw/master/RELEASES/zoomdisabler_1.2.0.zip",
-			"description": "Tired of zooming your document everytime you just want to scroll but accidentally still holding the [Ctrl] key? Then this is what you want! It disables mouse zoom, keyboard zoom, or both.",
-			"author": "Stanislav Eckert",
-			"homepage": "https://github.com/StanDog/npp-zoomdisabler"
 		}
 	]
 }

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -145,6 +145,16 @@
 			"homepage": "https://github.com/Natestah/BlitsNppPlugin"
 		},
 		{
+			"folder-name": "BunyanLogViewer",
+			"display-name": "Bunyan Log Viewer",
+			"version": "1.0.0",
+			"id": "CB3D00E6D3B99970CAFE07ECF4DC954B27423DD7A6F7419D8AD2A46724FA2330",
+			"repository": "https://github.com/jayapalb/nodepaddplus_bunyan-plugin/releases/download/v1.0.0/BunyanLogViewer_x64.zip",
+			"description": "Docked Bunyan log viewer for Notepad++ with Bunyan-style short formatting, in-pane search, and inline DEBUG/INFO/WARN/ERROR filters.",
+			"author": "Jayapal B",
+			"homepage": "https://github.com/jayapalb/nodepaddplus_bunyan-plugin"
+		},
+		{
 			"folder-name": "BookmarksDook",
 			"display-name": "Bookmarks@Dook",
 			"version": "4.1.2",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -2049,16 +2049,6 @@
 			"description": "Implementation of the Zen Coding method by Sergey Chikuyonok. Expand HTML, CSS, XML, XSLT and XSD from abbreviations\ntr#head1.header&gt;td*2 becomes &lt;tr id=\"head1\" class=\"header\"&gt;\n &lt;td&gt;&lt;/td&gt;\n &lt;td&gt;&lt;/td&gt;\n&lt;/tr&gt;\nUses the Python Script plugin.",
 			"author": "Dave Brotherstone",
 			"homepage": "https://github.com/bruderstein/ZenCoding-Python"
-		},
-		{
-			"folder-name": "zoomdisabler",
-			"display-name": "Zoom Disabler",
-			"version": "1.2.0",
-			"id": "eb49c4fce581fa63b024a3a0454ccc49d082b9524c0cc9a0d5c25544e264da55",
-			"repository": "https://github.com/StanDog/npp-zoomdisabler/raw/master/RELEASES/zoomdisabler_1.2.0.zip",
-			"description": "Tired of zooming your document everytime you just want to scroll but accidentally still holding the [Ctrl] key? Then this is what you want! It disables mouse zoom, keyboard zoom, or both.",
-			"author": "Stanislav Eckert",
-			"homepage": "https://github.com/StanDog/npp-zoomdisabler"
 		}
 	]
 }


### PR DESCRIPTION
Adds Bunyan Log Viewer to the x64 Notepad++ plugin list.

Release package:
https://github.com/jayapalb/nodepaddplus_bunyan-plugin/releases/download/v1.0.0/BunyanLogViewer_x64.zip

SHA-256:
CB3D00E6D3B99970CAFE07ECF4DC954B27423DD7A6F7419D8AD2A46724FA2330