### PR TITLE
Add Dark mode C plugin to the official list

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -62,7 +62,7 @@
 			"display-name": "Dark Mode C",
 			"version": "1.0.2",
 			"npp-compatible-versions": "[8.0,]",
-			"id": "54CBBA7128DEEA1F35EF8CF149E22AE6703AE44F27FEE552EA26FCE3CDB0738D",
+			"id": "282819DB8AAA6BA379886C79012277B906BD7F68381FBDDA21013A290C1B0B17",
 			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/1.0.2/DARK_MODE_NPP_ARM64.zip",
 			"description": "Adds toolbar icons to instantly switch between light and dark mode with no restart required. Features an automatic mode that dynamically toggles your theme based on local sunrise and sunset times.",
 			"author": "pullitall",

--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -60,10 +60,10 @@
 		{
 			"folder-name": "dark_mode_C",
 			"display-name": "Dark Mode C",
-			"version": "1.0.2",
+			"version": "1.0.3",
 			"npp-compatible-versions": "[8.0,]",
-			"id": "282819DB8AAA6BA379886C79012277B906BD7F68381FBDDA21013A290C1B0B17",
-			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/1.0.2/DARK_MODE_NPP_ARM64.zip",
+			"id": "0b90c891b9b7a39197f534ebc1197425b41e0caf6525261c85a27ffa7bf62843",
+			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/v1.0.3/DARK_MODE_NPP_v1.0.3_ARM64.zip",
 			"description": "Adds toolbar icons to instantly switch between light and dark mode with no restart required. Features an automatic mode that dynamically toggles your theme based on local sunrise and sunset times.",
 			"author": "pullitall",
 			"homepage": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location"

--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -58,6 +58,17 @@
 			"homepage": "https://github.com/pnedev/comparePlus"
 		},
 		{
+			"folder-name": "dark_mode_C",
+			"display-name": "Dark Mode C",
+			"version": "1.0.2",
+			"npp-compatible-versions": "[8.0,]",
+			"id": "54CBBA7128DEEA1F35EF8CF149E22AE6703AE44F27FEE552EA26FCE3CDB0738D",
+			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/1.0.2/DARK_MODE_NPP_ARM64.zip",
+			"description": "Adds toolbar icons to instantly switch between light and dark mode with no restart required. Features an automatic mode that dynamically toggles your theme based on local sunrise and sunset times.",
+			"author": "pullitall",
+			"homepage": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location"
+		},
+		{
 			"folder-name": "DiscordRPC",
 			"display-name": "Discord Rich Presence",
 			"version": "2.1.711.1",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -365,10 +365,10 @@
 		{
 			"folder-name": "dark_mode_C",
 			"display-name": "Dark Mode C",
-			"version": "1.0.2",
+			"version": "1.0.3",
 			"npp-compatible-versions": "[8.0,]",
-			"id": "B2C3F663DAE81D1A5BC152628BC848EE90B7A675262A90BEEE0423BAB0C1C079",
-			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/1.0.2/DARK_MODE_NPP_x64.zip",
+			"id": "80de8f99c39b34203de847f66a9db6b754b13f9f9afe05adb9327866a1ba9d6d",
+			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/v1.0.3/DARK_MODE_NPP_v1.0.3_x64.zip",
 			"description": "Adds toolbar icons to instantly switch between light and dark mode with no restart required. Features an automatic mode that dynamically toggles your theme based on local sunrise and sunset times.",
 			"author": "pullitall",
 			"homepage": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -363,6 +363,17 @@
 			"homepage": "https://sourceforge.net/projects/customlinenumbers"
 		},
 		{
+			"folder-name": "dark_mode_C",
+			"display-name": "Dark Mode C",
+			"version": "1.0.2",
+			"npp-compatible-versions": "[8.0,]",
+			"id": "33F60B772FDC443EF611B0447533893C4033572B35862DADC6DDA764E4A92CBA",
+			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/1.0.2/DARK_MODE_NPP_x64.zip",
+			"description": "Adds toolbar icons to instantly switch between light and dark mode with no restart required. Features an automatic mode that dynamically toggles your theme based on local sunrise and sunset times.",
+			"author": "pullitall",
+			"homepage": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location"
+		},
+		{
 			"folder-name": "dbgpPlugin",
 			"display-name": "DBGp",
 			"version": "0.14.2.1",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -367,7 +367,7 @@
 			"display-name": "Dark Mode C",
 			"version": "1.0.2",
 			"npp-compatible-versions": "[8.0,]",
-			"id": "33F60B772FDC443EF611B0447533893C4033572B35862DADC6DDA764E4A92CBA",
+			"id": "B2C3F663DAE81D1A5BC152628BC848EE90B7A675262A90BEEE0423BAB0C1C079",
 			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/1.0.2/DARK_MODE_NPP_x64.zip",
 			"description": "Adds toolbar icons to instantly switch between light and dark mode with no restart required. Features an automatic mode that dynamically toggles your theme based on local sunrise and sunset times.",
 			"author": "pullitall",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -332,7 +332,7 @@
 		{
 			"folder-name": "dark_mode_C",
 			"display-name": "Dark Mode C",
-			"version": "1.0.2",
+			"version": "1.0.3",
 			"npp-compatible-versions": "[8.0,]",
 			"id": "7be4d602ec6fa366b0b5fdcd93146c41baf67c0af50cd752ce8e47aee9dadcb89",
 			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/v1.0.3/DARK_MODE_NPP_v1.0.3_x86.zip",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -334,7 +334,7 @@
 			"display-name": "Dark Mode C",
 			"version": "1.0.3",
 			"npp-compatible-versions": "[8.0,]",
-			"id": "7be4d602ec6fa366b0b5fdcd93146c41baf67c0af50cd752ce8e47aee9dadcb89",
+			"id": "7be4d602ec6fa366b0b5fdcd93146c41baf67c0af50cd752ce8e47aee9dadcb8",
 			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/v1.0.3/DARK_MODE_NPP_v1.0.3_x86.zip",
 			"description": "Adds toolbar icons to instantly switch between light and dark mode with no restart required. Features an automatic mode that dynamically toggles your theme based on local sunrise and sunset times.",
 			"author": "pullitall",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -334,8 +334,8 @@
 			"display-name": "Dark Mode C",
 			"version": "1.0.2",
 			"npp-compatible-versions": "[8.0,]",
-			"id": "9CA1D72E1A5DBF3A399224507A517062369F7195CB66234CE88DAB4CD4345359",
-			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/1.0.2/DARK_MODE_NPP_x86.zip",
+			"id": "7be4d602ec6fa366b0b5fdcd93146c41baf67c0af50cd752ce8e47aee9dadcb89",
+			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/v1.0.3/DARK_MODE_NPP_v1.0.3_x86.zip",
 			"description": "Adds toolbar icons to instantly switch between light and dark mode with no restart required. Features an automatic mode that dynamically toggles your theme based on local sunrise and sunset times.",
 			"author": "pullitall",
 			"homepage": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -334,7 +334,7 @@
 			"display-name": "Dark Mode C",
 			"version": "1.0.2",
 			"npp-compatible-versions": "[8.0,]",
-			"id": "5FC89A635E7E7CC0592669A41C2E7E953739E2767422485B6F3BA023875B27C5",
+			"id": "9CA1D72E1A5DBF3A399224507A517062369F7195CB66234CE88DAB4CD4345359",
 			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/1.0.2/DARK_MODE_NPP_x86.zip",
 			"description": "Adds toolbar icons to instantly switch between light and dark mode with no restart required. Features an automatic mode that dynamically toggles your theme based on local sunrise and sunset times.",
 			"author": "pullitall",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -330,6 +330,17 @@
 			"homepage": "https://sourceforge.net/projects/customlinenumbers"
 		},
 		{
+			"folder-name": "dark_mode_C",
+			"display-name": "Dark Mode C",
+			"version": "1.0.2",
+			"npp-compatible-versions": "[8.0,]",
+			"id": "5FC89A635E7E7CC0592669A41C2E7E953739E2767422485B6F3BA023875B27C5",
+			"repository": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location/releases/download/1.0.2/DARK_MODE_NPP_x86.zip",
+			"description": "Adds toolbar icons to instantly switch between light and dark mode with no restart required. Features an automatic mode that dynamically toggles your theme based on local sunrise and sunset times.",
+			"author": "pullitall",
+			"homepage": "https://github.com/pullitall/Notepadpp-light-dark-switch-and-automatic-switch-based-on-location"
+		},
+		{
 			"folder-name": "DarkTheme",
 			"display-name": "Dark Theme Mode",
 			"version": "1.0",


### PR DESCRIPTION
Adds toolbar icons to instantly switch between light and dark mode with no restart required. Features an automatic mode that dynamically toggles your theme based on local sunrise and sunset times