### PR TITLE
MultiReplace 6.0.0.36

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -195,11 +195,11 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "5.0.0.35",
+			"version": "6.0.0.36",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "3487f2b17b0f851995541eb8055068fbaab8d312bc70203dab7f0387ed11afad",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/5.0.0.35/MultiReplace-v5.0.0.35-ARM64.zip",
-			"description": "Multi-pattern search & replace across single or multiple files; reusable search/replace lists; CSV column operations (sort, delete, replace); FlowTabs for visual column alignment; external lookup tables; rectangular selection support; conditional (if/then) and math logic.\r\n",
+			"id": "b322f2f58721d2c5439abfa43eb9356a7c81a265b86685b3385a6ddde03c2c3a",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/6.0.0.36/MultiReplace-v6.0.0.36-ARM64.zip",
+			"description": "Multi-pattern search & replace across single or multiple files; reusable search & replace lists; CSV column operations (sort, delete, deduplicate); FlowTabs for visual column alignment; dockable search results; rectangular selection support; Lua/ExprTk formula engine with conditional and math logic.\r\n",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"
 		},

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -856,11 +856,11 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "5.0.0.35",
+			"version": "6.0.0.36",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "9218099e90e43901029a01ba9131462bfe0aacfcda7d6338e18efd78deb5a858",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/5.0.0.35/MultiReplace-v5.0.0.35-x64.zip",
-			"description": "Multi-pattern search & replace across single or multiple files; reusable search/replace lists; CSV column operations (sort, delete, replace); FlowTabs for visual column alignment; external lookup tables; rectangular selection support; conditional (if/then) and math logic.\r\n",
+			"id": "e6a7fe3a230ed5c61b4f76bfba53e077d30a24b1d8bacb323784e4c02c90dcae",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/6.0.0.36/MultiReplace-v6.0.0.36-x64.zip",
+			"description": "Multi-pattern search & replace across single or multiple files; reusable search & replace lists; CSV column operations (sort, delete, deduplicate); FlowTabs for visual column alignment; dockable search results; rectangular selection support; Lua/ExprTk formula engine with conditional and math logic.\r\n",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"
 		},

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -912,11 +912,11 @@
 		{
 			"folder-name": "MultiReplace",
 			"display-name": "MultiReplace",
-			"version": "5.0.0.35",
+			"version": "6.0.0.36",
 			"npp-compatible-versions": "[8.5.4,]",
-			"id": "fc49ccac120b0f8c38c55856901de4dffe3ff2249a645971e195ab33b158e235",
-			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/5.0.0.35/MultiReplace-v5.0.0.35-Win32.zip",
-			"description": "Multi-pattern search & replace across single or multiple files; reusable search/replace lists; CSV column operations (sort, delete, replace); FlowTabs for visual column alignment; external lookup tables; rectangular selection support; conditional (if/then) and math logic.\r\n",
+			"id": "6d8f90993c01edf7402e53f77ff517cafa192955d28a636d9b4a81341c872fc5",
+			"repository": "https://github.com/daddel80/notepadpp-multireplace/releases/download/6.0.0.36/MultiReplace-v6.0.0.36-Win32.zip",
+			"description": "Multi-pattern search & replace across single or multiple files; reusable search & replace lists; CSV column operations (sort, delete, deduplicate); FlowTabs for visual column alignment; dockable search results; rectangular selection support; Lua/ExprTk formula engine with conditional and math logic.\r\n",
 			"author": "Thomas Knoefel",
 			"homepage": "https://github.com/daddel80/notepadpp-multireplace"
 		},


### PR DESCRIPTION
### Key Features & Improvements

* **New Formula Engine (ExprTk)**: A second engine alongside Lua for math, string and conditional replacements. Captures are available as numbers (`num(N)`) or text (`txt(N)`), with a built-in formatter for fixed decimals, hex/binary, padded fields, durations and dates. Switch per tab via the `(L)` / `(E)` indicator next to **Formula Support**. The `(?=...)` syntax was inspired by Coises' Columns++.
* **Formula Support**: The former *Use Variables* option, renamed for the two-engine model. Existing Lua workflows are unchanged.
* **List Tabs**: Keep multiple lists open side by side - add, rename, reorder, duplicate and save per tab. Tabs persist across sessions, with fully separate state.
* **Tandem Mode**: Docks the panel to a Notepad++ window edge and follows every move and resize. Toggle via the plugin menu.
* **Reopen on Startup**: Optionally reopens MultiReplace on the next launch if it was open at shutdown. Toggle via the plugin menu.
* **Compact Toolbar**: Reworked top toolbar with more horizontal space for the list.
* **Bookmark Matches**: Sets a Notepad++ bookmark on every matched line, via the checkbox next to **Mark Matches**.
* **Column Reorder & Lock**: Drag headers to rearrange; right-click for *Lock column width* or *Reset Column Order*.
* **Modified Timestamp Column**: Optional column tracking the last edit per entry, with a dirty-flag stripe for unsaved changes.
* **Pickup Selection (Ctrl+Shift+H)**: Pulls selected editor text into *Find what*, optionally auto-escaped for the active search mode.
* **Copy Report**: Copies the whole list to the clipboard in a customizable, spreadsheet-ready format via the context menu.

### Fixes

- **Combo History (Arrow Keys)**: Typing in a Find/Replace/Filter/Dir field and then pressing an arrow key no longer discards the unsaved text.
