### PR TITLE
Update Markdown Table Editor to 11.0.2

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -171,6 +171,17 @@
 			"homepage": "https://github.com/thosrtanner/notepad-pp-linter"
 		},
 		{
+			"folder-name": "MarkdownTableEditor",
+			"display-name": "Markdown Table Editor",
+			"version": "10.0.0",
+			"npp-compatible-versions": "[8.3.1,]",
+			"id": "dae9ce1668b07d88e563537efe040c6c0c70aca4b05d96ec6722504b5edb9c54",
+			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v10.0.0/MarkdownTableEditor-10.0.0-arm64-pluginadmin.zip",
+			"description": "Edits Markdown pipe tables as aligned text. Align, wrap long cells, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV selections or current blocks, and insert new tables from Notepad++.",
+			"author": "Kreout",
+			"homepage": "https://github.com/krotname/NppMarkdownTableEditor"
+		},
+		{
 			"folder-name": "MenuIcons",
 			"display-name": "MenuIcons",
 			"version": "2.0.7",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -812,6 +812,17 @@
 			"homepage": "https://github.com/mohzy83/NppMarkdownPanel"
 		},
 		{
+			"folder-name": "MarkdownTableEditor",
+			"display-name": "Markdown Table Editor",
+			"version": "10.0.0",
+			"npp-compatible-versions": "[8.3.1,]",
+			"id": "03aaa4abd3a68fe5e6a56268e4f588c225c4d1f8b4e1c06efa97cf7cc5ac765b",
+			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v10.0.0/MarkdownTableEditor-10.0.0-x64-pluginadmin.zip",
+			"description": "Edits Markdown pipe tables as aligned text. Align, wrap long cells, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV selections or current blocks, and insert new tables from Notepad++.",
+			"author": "Kreout",
+			"homepage": "https://github.com/krotname/NppMarkdownTableEditor"
+		},
+		{
 			"folder-name": "MarkdownViewerPlusPlus",
 			"display-name": "MarkdownViewer++",
 			"version": "0.8.2",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -858,6 +858,17 @@
 			"homepage": "https://github.com/mohzy83/NppMarkdownPanel"
 		},
 		{
+			"folder-name": "MarkdownTableEditor",
+			"display-name": "Markdown Table Editor",
+			"version": "10.0.0",
+			"npp-compatible-versions": "[7.5.9,]",
+			"id": "10244310f3d9aa5c9eac50771b88a80d77f25545caaa262ec3cbc1e2b122f917",
+			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v10.0.0/MarkdownTableEditor-10.0.0-x86-pluginadmin.zip",
+			"description": "Edits Markdown pipe tables as aligned text. Align, wrap long cells, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV selections or current blocks, and insert new tables from Notepad++.",
+			"author": "Kreout",
+			"homepage": "https://github.com/krotname/NppMarkdownTableEditor"
+		},
+		{
 			"folder-name": "MarkdownViewerPlusPlus",
 			"display-name": "MarkdownViewer++",
 			"version": "0.8.2",


### PR DESCRIPTION
Adds Markdown Table Editor 11.0.2 to the Plugin Admin manifests for x86, x64, and arm64.

Release: https://github.com/krotname/NppMarkdownTableEditor/releases/tag/v11.0.2

Published Plugin Admin SHA-256 hashes:

- x86: `2f8fe08ab6c4c55b2111df2de398ecb185fa2691dea41083fad0e1f2138cb785`
- x64: `1c22f73d52b3586e00d8a757dd9af52589d497659dca81fb2c5b26d06d2ed553`
- arm64: `e6652a689d6b1781a23fb578eb9034dbbfd483ca608348ca4379b708465c0c6e`

Validation performed:

- `python -m pip install -r requirements.txt`
- `./sort_plugin_lists.ps1`
- `python -m json.tool src/pl.x86.json`, `src/pl.x64.json`, and `src/pl.arm64.json`
- `python validator.py x86`
- `python validator.py x64`
- `python validator.py arm64`
- `python validator.py all_md`
- Downloaded the published `*-pluginadmin.zip` assets and verified SHA-256 against the GitHub release digests.
- `git diff --check`

The PR diff is limited to the three manifest files: `src/pl.x86.json`, `src/pl.x64.json`, and `src/pl.arm64.json`.