### PR TITLE
Update Markdown Table Editor to 11.0.0

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -184,11 +184,11 @@
 		{
 			"folder-name": "MarkdownTableEditor",
 			"display-name": "Markdown Table Editor",
-			"version": "10.0.0",
+			"version": "11.0.0",
 			"npp-compatible-versions": "[8.3.1,]",
-			"id": "dae9ce1668b07d88e563537efe040c6c0c70aca4b05d96ec6722504b5edb9c54",
-			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v10.0.0/MarkdownTableEditor-10.0.0-arm64-pluginadmin.zip",
-			"description": "Edits Markdown pipe tables as aligned text. Align, wrap long cells, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV selections or current blocks, and insert new tables from Notepad++.",
+			"id": "59557810d2dd5bea53e331d872fecd9e21825e2150f8a77af1814022a30c13a1",
+			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.0.0/MarkdownTableEditor-11.0.0-arm64-pluginadmin.zip",
+			"description": "Edits Markdown pipe tables as aligned text. Align, fit width, narrow or widen columns, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV blocks, and insert new tables from Notepad++.",
 			"author": "Kreout",
 			"homepage": "https://github.com/krotname/NppMarkdownTableEditor"
 		},

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -835,11 +835,11 @@
 		{
 			"folder-name": "MarkdownTableEditor",
 			"display-name": "Markdown Table Editor",
-			"version": "10.0.0",
+			"version": "11.0.0",
 			"npp-compatible-versions": "[8.3.1,]",
-			"id": "03aaa4abd3a68fe5e6a56268e4f588c225c4d1f8b4e1c06efa97cf7cc5ac765b",
-			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v10.0.0/MarkdownTableEditor-10.0.0-x64-pluginadmin.zip",
-			"description": "Edits Markdown pipe tables as aligned text. Align, wrap long cells, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV selections or current blocks, and insert new tables from Notepad++.",
+			"id": "3761f726c4355a49fb774d7c3f677f8915280159dc3e54ae4dd7dd2e707799e4",
+			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.0.0/MarkdownTableEditor-11.0.0-x64-pluginadmin.zip",
+			"description": "Edits Markdown pipe tables as aligned text. Align, fit width, narrow or widen columns, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV blocks, and insert new tables from Notepad++.",
 			"author": "Kreout",
 			"homepage": "https://github.com/krotname/NppMarkdownTableEditor"
 		},

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -871,11 +871,11 @@
 		{
 			"folder-name": "MarkdownTableEditor",
 			"display-name": "Markdown Table Editor",
-			"version": "10.0.0",
+			"version": "11.0.0",
 			"npp-compatible-versions": "[7.5.9,]",
-			"id": "10244310f3d9aa5c9eac50771b88a80d77f25545caaa262ec3cbc1e2b122f917",
-			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v10.0.0/MarkdownTableEditor-10.0.0-x86-pluginadmin.zip",
-			"description": "Edits Markdown pipe tables as aligned text. Align, wrap long cells, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV selections or current blocks, and insert new tables from Notepad++.",
+			"id": "ec9326c72d866a9f0aca3b6ceebcf40343c9b9852a42407f53cf27b80fea3992",
+			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.0.0/MarkdownTableEditor-11.0.0-x86-pluginadmin.zip",
+			"description": "Edits Markdown pipe tables as aligned text. Align, fit width, narrow or widen columns, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV blocks, and insert new tables from Notepad++.",
 			"author": "Kreout",
 			"homepage": "https://github.com/krotname/NppMarkdownTableEditor"
 		},


### PR DESCRIPTION
Updates Markdown Table Editor to 11.0.0 for x86, x64, and ARM64.

Release: https://github.com/krotname/NppMarkdownTableEditor/releases/tag/v11.0.0

Published Plugin Admin asset hashes:

- x86: `ec9326c72d866a9f0aca3b6ceebcf40343c9b9852a42407f53cf27b80fea3992`
- x64: `3761f726c4355a49fb774d7c3f677f8915280159dc3e54ae4dd7dd2e707799e4`
- ARM64: `59557810d2dd5bea53e331d872fecd9e21825e2150f8a77af1814022a30c13a1`

Local validation:

- Downloaded the published x86/x64/ARM64 Plugin Admin ZIPs and verified SHA-256, ZIP structure, `MarkdownTableEditor.dll`, and `FileVersion/ProductVersion = 11.0.0`.
- Ran `python validator.py x86`, `python validator.py x64`, and `python validator.py arm64` with a per-request timeout to avoid indefinite hangs on unrelated external plugin URLs; all completed without validator errors.
- Ran `python validator.py all_md` successfully, then left generated `doc/plugin_list_*.md` files out of this PR so the diff only contains the three JSON manifests.

CI status:

- `CI_build / build (Release, Win32)`: passed.
- `CI_build / build (Release, x64)`: passed.
- `CI_build / build (Release, arm64)`: passed.

Note: PR #1115 was already merged for Markdown Table Editor 10.0.0, so this PR carries the next 11.0.0 update.
