### PR TITLE
Add FixParser plugin

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -565,6 +565,17 @@
 			"homepage": "https://github.com/shriprem/FWDataViz"
 		},
 		{
+			"folder-name": "FixParser",
+			"display-name": "FixParser",
+			"version": "0.1.3",
+			"npp-compatible-versions": "[8.9.0,]",
+			"id": "ce42010f9cf6b8eb7c8fdc34e618554f2f89febd077bbe6008bda44ccdee4798",
+			"repository": "https://github.com/chtaylo3/fix-parser/releases/download/v0.1.3/FixParser_0.1.3_x64.zip",
+			"description": "Pretty-print and inspect FIX protocol logs: field/value decoding, hover quickview, and a dockable message inspector.",
+			"author": "Chris Taylor",
+			"homepage": "https://github.com/chtaylo3/fix-parser"
+		},
+		{
 			"folder-name": "FoldingLineHider",
 			"display-name": "Folding Line Hider",
 			"version": "1.1",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -559,6 +559,17 @@
 			"homepage": "https://github.com/shriprem/FWDataViz"
 		},
 		{
+			"folder-name": "FixParser",
+			"display-name": "FixParser",
+			"version": "0.1.3",
+			"npp-compatible-versions": "[8.9.0,]",
+			"id": "a63d531ea0cb83d5303f75e1587ffcb65c3fe9628d14cd4f3286834705c85ed0",
+			"repository": "https://github.com/chtaylo3/fix-parser/releases/download/v0.1.3/FixParser_0.1.3_Win32.zip",
+			"description": "Pretty-print and inspect FIX protocol logs: field/value decoding, hover quickview, and a dockable message inspector.",
+			"author": "Chris Taylor",
+			"homepage": "https://github.com/chtaylo3/fix-parser"
+		},
+		{
 			"folder-name": "FoldingLineHider",
 			"display-name": "Folding Line Hider",
 			"version": "1.1",


### PR DESCRIPTION
New plugin: FixParser - pretty-prints and inspects FIX protocol logs (field/value decoding, hover quickview, dockable inspector). Release: https://github.com/chtaylo3/fix-parser/releases/tag/v0.1.3 . Requires Notepad++ >= 8.9.0. Validated locally with validator.py (x64, x86) and smoke-tested on both architectures.