### PR TITLE
Update Emoji Description to 0.2.14

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -81,9 +81,9 @@
 		{
 			"folder-name": "EmojiDescription",
 			"display-name": "Emoji Description",
-			"version": "0.1.0",
-			"id": "581fe7911d8f76edde26009fdc4cf5860cc34cd67fa996381f883eda936fcf10",
-			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.1.0/EmojiDescription_arm64_v0.1.0.zip",
+			"version": "0.2.14",
+			"id": "f9b83fdae23278dda0166590576d4dea1c1d25e6c641612b5841203997a2b939",
+			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.2.14/EmojiDescription_arm64_v0.2.14.zip",
 			"description": "Displays detailed character encoding information in the status bar. Shows Unicode code point, decimal/hexadecimal values, HTML entity, and UTF-8 byte sequence for any character including emoji.",
 			"author": "Ruberoid",
 			"homepage": "https://github.com/Ruberoid/npp_emoji_description"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -461,9 +461,9 @@
 		{
 			"folder-name": "EmojiDescription",
 			"display-name": "Emoji Description",
-			"version": "0.1.0",
-			"id": "308b06c81412e2db395f96ae21e2d497c12a6249106b7db5e5e2da2ace7c9c51",
-			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.1.0/EmojiDescription_x64_v0.1.0.zip",
+			"version": "0.2.14",
+			"id": "33dacacaf402b93dfe0aae8b39adaf2a029000747fa67069621757237990df77",
+			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.2.14/EmojiDescription_x64_v0.2.14.zip",
 			"description": "Displays detailed character encoding information in the status bar. Shows Unicode code point, decimal/hexadecimal values, HTML entity, and UTF-8 byte sequence for any character including emoji.",
 			"author": "Ruberoid",
 			"homepage": "https://github.com/Ruberoid/npp_emoji_description"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -437,9 +437,9 @@
 		{
 			"folder-name": "EmojiDescription",
 			"display-name": "Emoji Description",
-			"version": "0.1.0",
-			"id": "4d4fa84a1ace691970cf2502995bd955ccc75ddba01a64354835c17e59c61d22",
-			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.1.0/EmojiDescription_x86_v0.1.0.zip",
+			"version": "0.2.14",
+			"id": "105a85da9f1ee548066b85f06c3ddb900e959ace4005546f7b448c5017f8487b",
+			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.2.14/EmojiDescription_x86_v0.2.14.zip",
 			"description": "Displays detailed character encoding information in the status bar. Shows Unicode code point, decimal/hexadecimal values, HTML entity, and UTF-8 byte sequence for any character including emoji.",
 			"author": "Ruberoid",
 			"homepage": "https://github.com/Ruberoid/npp_emoji_description"


### PR DESCRIPTION
This updates the existing **Emoji Description** plugin entry (originally added in #1021) from v0.1.0 to **v0.2.14** across all three architecture lists.

**Changes (one entry per file, 3 fields each):**
- `version`: 0.1.0 → 0.2.14
- `repository`: download URLs repointed to the v0.2.14 release
- `id`: SHA-256 of each new release ZIP

| Arch | SHA-256 (zip) |
|------|----------------|
| x64 | `33dacacaf402b93dfe0aae8b39adaf2a029000747fa67069621757237990df77` |
| x86 | `105a85da9f1ee548066b85f06c3ddb900e959ace4005546f7b448c5017f8487b` |
| arm64 | `f9b83fdae23278dda0166590576d4dea1c1d25e6c641612b5841203997a2b939` |

**Release:** https://github.com/Ruberoid/npp_emoji_description/releases/tag/v0.2.14
Built for x64, x86 and ARM64 via CI (MSVC, v143 toolset); each ZIP verified to contain a DLL of the matching architecture.

**What's new in 0.2.14:** per-field display toggles, optional Unicode character name in the status bar (BMP), and settings persisted between sessions. See the [changelog](https://github.com/Ruberoid/npp_emoji_description/blob/main/CHANGELOG.md).

Open-source (GPL v2), same repository and author as the original entry.
