### PR TITLE
Update Markdown Table Editor to 11.0.2

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -184,10 +184,10 @@
 		{
 			"folder-name": "MarkdownTableEditor",
 			"display-name": "Markdown Table Editor",
-			"version": "11.0.0",
+			"version": "11.0.2",
 			"npp-compatible-versions": "[8.3.1,]",
-			"id": "59557810d2dd5bea53e331d872fecd9e21825e2150f8a77af1814022a30c13a1",
-			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.0.0/MarkdownTableEditor-11.0.0-arm64-pluginadmin.zip",
+			"id": "e6652a689d6b1781a23fb578eb9034dbbfd483ca608348ca4379b708465c0c6e",
+			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.0.2/MarkdownTableEditor-11.0.2-arm64-pluginadmin.zip",
 			"description": "Edits Markdown pipe tables as aligned text. Align, fit width, narrow or widen columns, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV blocks, and insert new tables from Notepad++.",
 			"author": "Kreout",
 			"homepage": "https://github.com/krotname/NppMarkdownTableEditor"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -846,10 +846,10 @@
 		{
 			"folder-name": "MarkdownTableEditor",
 			"display-name": "Markdown Table Editor",
-			"version": "11.0.0",
+			"version": "11.0.2",
 			"npp-compatible-versions": "[8.3.1,]",
-			"id": "3761f726c4355a49fb774d7c3f677f8915280159dc3e54ae4dd7dd2e707799e4",
-			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.0.0/MarkdownTableEditor-11.0.0-x64-pluginadmin.zip",
+			"id": "1c22f73d52b3586e00d8a757dd9af52589d497659dca81fb2c5b26d06d2ed553",
+			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.0.2/MarkdownTableEditor-11.0.2-x64-pluginadmin.zip",
 			"description": "Edits Markdown pipe tables as aligned text. Align, fit width, narrow or widen columns, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV blocks, and insert new tables from Notepad++.",
 			"author": "Kreout",
 			"homepage": "https://github.com/krotname/NppMarkdownTableEditor"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -882,10 +882,10 @@
 		{
 			"folder-name": "MarkdownTableEditor",
 			"display-name": "Markdown Table Editor",
-			"version": "11.0.0",
+			"version": "11.0.2",
 			"npp-compatible-versions": "[7.5.9,]",
-			"id": "ec9326c72d866a9f0aca3b6ceebcf40343c9b9852a42407f53cf27b80fea3992",
-			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.0.0/MarkdownTableEditor-11.0.0-x86-pluginadmin.zip",
+			"id": "2f8fe08ab6c4c55b2111df2de398ecb185fa2691dea41083fad0e1f2138cb785",
+			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.0.2/MarkdownTableEditor-11.0.2-x86-pluginadmin.zip",
 			"description": "Edits Markdown pipe tables as aligned text. Align, fit width, narrow or widen columns, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV blocks, and insert new tables from Notepad++.",
 			"author": "Kreout",
 			"homepage": "https://github.com/krotname/NppMarkdownTableEditor"


### PR DESCRIPTION
Updates Markdown Table Editor from 11.0.0 to 11.0.2 in the Plugin Admin manifests for x86, x64, and arm64.

Release: https://github.com/krotname/NppMarkdownTableEditor/releases/tag/v11.0.2

Published Plugin Admin SHA-256 hashes:

- x86: `2f8fe08ab6c4c55b2111df2de398ecb185fa2691dea41083fad0e1f2138cb785`
- x64: `1c22f73d52b3586e00d8a757dd9af52589d497659dca81fb2c5b26d06d2ed553`
- arm64: `e6652a689d6b1781a23fb578eb9034dbbfd483ca608348ca4379b708465c0c6e`

Validation performed:

- `python -m json.tool src/pl.x86.json`, `src/pl.x64.json`, and `src/pl.arm64.json`
- `python validator.py x86`
- `python validator.py x64`
- `python validator.py arm64`
- `python validator.py all_md`
- Downloaded the published `*-pluginadmin.zip` assets and verified SHA-256 against the GitHub release digests.
- `git diff --check`

The PR diff is limited to the three manifest files: `src/pl.x86.json`, `src/pl.x64.json`, and `src/pl.arm64.json`.