### PR TITLE
Update HLASMLexer to 1.1.0

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -635,9 +635,9 @@
 		{
 			"folder-name": "HLASMLexer",
 			"display-name": "HLASM Lexer - Column-Aware Syntax Highlighting",
-			"version": "1.0.0",
-			"id": "4bf87ca7aed8d068169d588d1ac791ee10fadef5f1f5a566915d5990440fec95",
-			"repository": "https://github.com/Zaneham/hlasm-npp/releases/download/v1.0.1/HLASMLexer_x64.zip",
+			"version": "1.1.0",
+			"id": "506c27ddea0242554c6f08abd7dbedad1273a6027db27b57faf1e4b22bd63142",
+			"repository": "https://github.com/Zaneham/hlasm-npp/releases/download/v1.1.0/HLASMLexer_x64.zip",
 			"description": "Column-aware syntax highlighting for IBM HLASM. Understands the 80-column punch card layout — labels, operations, operands, continuation markers and sequence numbers are each highlighted by their column position, not just keywords.",
 			"author": "Zane Hambly",
 			"homepage": "https://github.com/Zaneham/hlasm-npp"


### PR DESCRIPTION
Bumps the HLASMLexer entry to v1.1.0. The plugin is now a proper Scintilla/Lexilla ILexer5 lexer rather than direct styling, so HLASM registers as a real language with sticky highlighting and built-in colours. SHA-256 verified against the v1.1.0 release asset.