### PR TITLE
Tree-sitter plugin update to v1.4.2

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -519,9 +519,9 @@
 		{
 			"folder-name": "TreeSitterLexer",
 			"display-name": "TreeSitter",
-			"version": "1.4.1",
-			"id": "f1ce5ca0def6b8811e26a0ea7316cf2dd85d4ff1fc18e7adf08757f439da5867",
-			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.4.1/NppTreeSitter_1.4.1_ARM64.zip",
+			"version": "1.4.2",
+			"id": "757485b3b8730ef7e75934401832f8abd82dfa6dc630fee010e5f1ec85ba6c0f",
+			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.4.2/NppTreeSitter_1.4.2_ARM64.zip",
 			"description": "Integrate Tree-sitter to Notepad++. AST-based syntax highlighting and code folding for many languages.",
 			"author": "Tuomas Hietanen",
 			"homepage": "https://github.com/Thorium/NppTreeSitter/"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1828,9 +1828,9 @@
 		{
 			"folder-name": "TreeSitterLexer",
 			"display-name": "TreeSitter",
-			"version": "1.4.1",
-			"id": "b8a50b977f52ac9585eb05f2021e5d1226ea9e9bf1f360830039ece4ea2fa871",
-			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.4.1/NppTreeSitter_1.4.1_x64.zip",
+			"version": "1.4.2",
+			"id": "6e76d0cbb0d707364444e7d9a0e4bcb14ebc8b54a3de21aa79a34899ab2e3c9b",
+			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.4.2/NppTreeSitter_1.4.2_x64.zip",
 			"description": "Integrate Tree-sitter to Notepad++. AST-based syntax highlighting and code folding for many languages.",
 			"author": "Tuomas Hietanen",
 			"homepage": "https://github.com/Thorium/NppTreeSitter/"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1934,9 +1934,9 @@
 		{
 			"folder-name": "TreeSitterLexer",
 			"display-name": "TreeSitter",
-			"version": "1.4.1",
-			"id": "45719a626d2c3b3d4c77891b04f2b89b32c17679203cce2231856ad7d1a8ab1e",
-			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.4.1/NppTreeSitter_1.4.1_Win32.zip",
+			"version": "1.4.2",
+			"id": "b74bc1627a907f7f23c3369d6f706a7e0a944860b49e2f12dc8bb503c10d33e2",
+			"repository": "https://github.com/Thorium/NppTreeSitter/releases/download/1.4.2/NppTreeSitter_1.4.2_Win32.zip",
 			"description": "Integrate Tree-sitter to Notepad++. AST-based syntax highlighting and code folding for many languages.",
 			"author": "Tuomas Hietanen",
 			"homepage": "https://github.com/Thorium/NppTreeSitter/"


### PR DESCRIPTION
Update TreeSitter plugin to v1.4.2 for x64, x86 and ARM64.

Release: https://github.com/Thorium/NppTreeSitter/releases/tag/1.4.2

Changes in this version:
- More filetypes supported (csproj/xaml and other XML-family extensions, geojson/ipynb, CUDA/Arduino C++, Bazel, various config files)
- Performance improvements in syntax highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)