### PR TITLE
Add Datamodder SQL Formatter (FormatSQL) plugin

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -587,6 +587,17 @@
 			"homepage": "https://github.com/leonardchai/FoldingLineHider"
 		},
 		{
+			"folder-name": "FormatSQL",
+			"display-name": "Datamodder SQL Formatter",
+			"version": "1.3.1.2",
+			"npp-compatible-versions": "[8.3,]",
+			"id": "e4837de661ed176dd5f05ca649ccc9eebcd195247f59ccd2df1c2ba2c3d2e2ed",
+			"repository": "https://github.com/dm-utils/formatsql/releases/download/v1.3.1.2/FormatSQL.zip",
+			"description": "Formats, minifies and converts SQL directly in Notepad++.\r\nFeatures:\r\n- Format / minify SQL, format-on-save, format-and-copy\r\n- Multi-dialect conversion (ANSI, Snowflake, MS SQL, PostgreSQL, MySQL, Databricks)\r\n- Quote, comment-style, boolean and number-format conversion\r\n- Configurable casing, alignment, structure and spacing rules with saved profiles",
+			"author": "Datamodder",
+			"homepage": "https://github.com/dm-utils/formatsql"
+		},
+		{
 			"folder-name": "GedcomLexer",
 			"display-name": "GEDCOM Lexer",
 			"version": "0.5.0.170",


### PR DESCRIPTION
## Plugin

**Datamodder SQL Formatter** (folder-name: `FormatSQL`) — a SQL formatter, minifier and dialect converter for Notepad++.

- Repository: https://github.com/dm-utils/formatsql
- Release used: https://github.com/dm-utils/formatsql/releases/tag/v1.3.1.2
- License: MIT
- 64-bit only (this PR adds an entry to `src/pl.x64.json` only)

## Validation performed

- [x] Entry validated against `pl.schema` with `jsonschema` (whole file, including this entry, passes)
- [x] `id` is the SHA-256 of the release zip, confirmed against GitHub's own asset digest for the release
- [x] Entry inserted in alphabetical order by `folder-name` (after `FoldingLineHider`, before `GedcomLexer`)
- [x] Plugin itself manually built, installed and exercised in a real Notepad++ install (not via Plugin Admin's list mechanism)
- [ ] Not yet tested via Notepad++'s Plugin Admin local-list install flow specifically — happy to do that and report back if that's expected before review.