### PR TITLE
Update Emoji Description to v0.3.16

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -81,9 +81,9 @@
 		{
 			"folder-name": "EmojiDescription",
 			"display-name": "Emoji Description",
-			"version": "0.2.14",
-			"id": "f9b83fdae23278dda0166590576d4dea1c1d25e6c641612b5841203997a2b939",
-			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.2.14/EmojiDescription_arm64_v0.2.14.zip",
+			"version": "0.3.16",
+			"id": "293bcb62c8cbc389e8552a6eeae34dcd013402322c60da6094f107c767109d1f",
+			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.3.16/EmojiDescription_arm64_v0.3.16.zip",
 			"description": "Displays detailed character encoding information in the status bar. Shows Unicode code point, decimal/hexadecimal values, HTML entity, and UTF-8 byte sequence for any character including emoji.",
 			"author": "Ruberoid",
 			"homepage": "https://github.com/Ruberoid/npp_emoji_description"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -461,9 +461,9 @@
 		{
 			"folder-name": "EmojiDescription",
 			"display-name": "Emoji Description",
-			"version": "0.2.14",
-			"id": "33dacacaf402b93dfe0aae8b39adaf2a029000747fa67069621757237990df77",
-			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.2.14/EmojiDescription_x64_v0.2.14.zip",
+			"version": "0.3.16",
+			"id": "62102bba90ef9b9e58c832fe3c5a67e4dffce5e18389ddf931c4ae0471675ddc",
+			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.3.16/EmojiDescription_x64_v0.3.16.zip",
 			"description": "Displays detailed character encoding information in the status bar. Shows Unicode code point, decimal/hexadecimal values, HTML entity, and UTF-8 byte sequence for any character including emoji.",
 			"author": "Ruberoid",
 			"homepage": "https://github.com/Ruberoid/npp_emoji_description"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -437,9 +437,9 @@
 		{
 			"folder-name": "EmojiDescription",
 			"display-name": "Emoji Description",
-			"version": "0.2.14",
-			"id": "105a85da9f1ee548066b85f06c3ddb900e959ace4005546f7b448c5017f8487b",
-			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.2.14/EmojiDescription_x86_v0.2.14.zip",
+			"version": "0.3.16",
+			"id": "b84c19588bbed9ff04d26d0f998b7835c2ed4468942f9355ad4e205c523168b8",
+			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.3.16/EmojiDescription_x86_v0.3.16.zip",
 			"description": "Displays detailed character encoding information in the status bar. Shows Unicode code point, decimal/hexadecimal values, HTML entity, and UTF-8 byte sequence for any character including emoji.",
 			"author": "Ruberoid",
 			"homepage": "https://github.com/Ruberoid/npp_emoji_description"


### PR DESCRIPTION
Updates **Emoji Description** to v0.3.16 in `pl.x64.json`, `pl.x86.json` and `pl.arm64.json` (version, download URL, and SHA-256 `id`).

### What changed in this release
- Fix (#9): the plugin no longer hides the file's language / document type in the status bar. Character info is now appended after the native language description (e.g. `C++ source file | U+1F600  😀  …`) instead of overwriting the `DOC_TYPE` segment. Disabling the feature immediately restores the language text.

Release: https://github.com/Ruberoid/npp_emoji_description/releases/tag/v0.3.16
Repository: https://github.com/Ruberoid/npp_emoji_description