### PR TITLE
Add LLM Assistant to plugin list

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -812,6 +812,16 @@
 			"homepage": "https://github.com/thosrtanner/notepad-pp-linter"
 		},
 		{
+			"folder-name": "LLMAssistant",
+			"display-name": "LLM Assistant",
+			"version": "1.0",
+			"id": "d13e692bb8da61ee4168df1065d7abb30dc58977c71a665710f1fee25ac6fe32",
+			"repository": "https://github.com/Gvo87/NotepadPlusPlus-LLM-Plugin/releases/download/v1.0/LLMAssistant_v1.0_x64.zip",
+			"description": "AI-powered text processing (enhance, translate, summarize, grammar, code) via the OpenAI API, directly inside Notepad++.",
+			"author": "Gvo87",
+			"homepage": "https://github.com/Gvo87/NotepadPlusPlus-LLM-Plugin"
+		},
+		{
 			"folder-name": "LocationNavigate",
 			"display-name": "Location Navigate",
 			"version": "0.4.8.1",


### PR DESCRIPTION
Adds **LLM Assistant** to the x64 plugin list (`src/pl.x64.json`).

LLM Assistant brings AI-powered text processing (enhance, translate, summarize, grammar check, code generation, and custom prompts) into Notepad++ via the OpenAI API.

- **Repo:** https://github.com/Gvo87/NotepadPlusPlus-LLM-Plugin
- **Release:** https://github.com/Gvo87/NotepadPlusPlus-LLM-Plugin/releases/tag/v1.0
- **Arch:** x64 only

### Entry
```json
{
  "folder-name": "LLMAssistant",
  "display-name": "LLM Assistant",
  "version": "1.0",
  "id": "d13e692bb8da61ee4168df1065d7abb30dc58977c71a665710f1fee25ac6fe32",
  "repository": "https://github.com/Gvo87/NotepadPlusPlus-LLM-Plugin/releases/download/v1.0/LLMAssistant_v1.0_x64.zip",
  "description": "AI-powered text processing (enhance, translate, summarize, grammar, code) via the OpenAI API, directly inside Notepad++.",
  "author": "Gvo87",
  "homepage": "https://github.com/Gvo87/NotepadPlusPlus-LLM-Plugin"
}
```

### Checklist
- [x] Only `src/pl.x64.json` is modified
- [x] `folder-name` is unique and matches the DLL name (`LLMAssistant.dll`)
- [x] DLL is at the root of the zip
- [x] `id` is the SHA-256 of the release zip (verified against the published asset)
- [x] `repository` is a direct, publicly downloadable `.zip`
- [x] DLL carries a binary version (`1.0.0.0`) for update detection
- [x] Tested locally with a debug Notepad++: the plugin lists in Plugins Admin with correct metadata and the DLL loads
