### PR TITLE
Update Markdown Table Editor to 11.1.0

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -184,10 +184,10 @@
 		{
 			"folder-name": "MarkdownTableEditor",
 			"display-name": "Markdown Table Editor",
-			"version": "11.0.2",
+			"version": "11.1.0",
 			"npp-compatible-versions": "[8.3.1,]",
-			"id": "e6652a689d6b1781a23fb578eb9034dbbfd483ca608348ca4379b708465c0c6e",
-			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.0.2/MarkdownTableEditor-11.0.2-arm64-pluginadmin.zip",
+			"id": "37ed2e3ac28b514d3267e9bcd0cca18683d67ae817075e9f91a5b944c78e18ea",
+			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.1.0/MarkdownTableEditor-11.1.0-arm64-pluginadmin.zip",
 			"description": "Edits Markdown pipe tables as aligned text. Align, fit width, narrow or widen columns, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV blocks, and insert new tables from Notepad++.",
 			"author": "Kreout",
 			"homepage": "https://github.com/krotname/NppMarkdownTableEditor"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -867,10 +867,10 @@
 		{
 			"folder-name": "MarkdownTableEditor",
 			"display-name": "Markdown Table Editor",
-			"version": "11.0.2",
+			"version": "11.1.0",
 			"npp-compatible-versions": "[8.3.1,]",
-			"id": "1c22f73d52b3586e00d8a757dd9af52589d497659dca81fb2c5b26d06d2ed553",
-			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.0.2/MarkdownTableEditor-11.0.2-x64-pluginadmin.zip",
+			"id": "a39a5f4cce2b726c585b80d142c755b1d2cd7cd3ef8c1afe6e3be41c0ff5fa40",
+			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.1.0/MarkdownTableEditor-11.1.0-x64-pluginadmin.zip",
 			"description": "Edits Markdown pipe tables as aligned text. Align, fit width, narrow or widen columns, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV blocks, and insert new tables from Notepad++.",
 			"author": "Kreout",
 			"homepage": "https://github.com/krotname/NppMarkdownTableEditor"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -882,10 +882,10 @@
 		{
 			"folder-name": "MarkdownTableEditor",
 			"display-name": "Markdown Table Editor",
-			"version": "11.0.2",
+			"version": "11.1.0",
 			"npp-compatible-versions": "[7.5.9,]",
-			"id": "2f8fe08ab6c4c55b2111df2de398ecb185fa2691dea41083fad0e1f2138cb785",
-			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.0.2/MarkdownTableEditor-11.0.2-x86-pluginadmin.zip",
+			"id": "8d5b66e539cceef2bce664433616eacdf57c22cbd590d155f11c5d6266877bf5",
+			"repository": "https://github.com/krotname/NppMarkdownTableEditor/releases/download/v11.1.0/MarkdownTableEditor-11.1.0-x86-pluginadmin.zip",
 			"description": "Edits Markdown pipe tables as aligned text. Align, fit width, narrow or widen columns, navigate, insert, delete, move and sort rows or columns, convert CSV/TSV blocks, and insert new tables from Notepad++.",
 			"author": "Kreout",
 			"homepage": "https://github.com/krotname/NppMarkdownTableEditor"


### PR DESCRIPTION
Updates Markdown Table Editor from 11.0.2 to 11.1.0 for x86, x64 and arm64.

Release: https://github.com/krotname/NppMarkdownTableEditor/releases/tag/v11.1.0

This replaces the earlier 11.0.4 revision of this PR while it was still open, so the list moves straight to the current release.

## What changed in the plugin

11.0.4 was a bug-fix release for the Markdown table engine:

- a separator line right after a table no longer starts a second, overlapping table that reused the
  previous table's last row as its header, which could corrupt a document when reformatting;
- tables written without outer pipes keep the outer pipe whenever the first or last column holds an
  empty cell, so inserting a column no longer silently drops one on the next parse;
- deleting down to a single column in such a table no longer leaves rows without any pipe at all;
- a header made only of dashes is no longer mistaken for the separator row.

11.1.0 adds no functional change on top of that. It aligns versions and licensing across the whole
Markdown Table Editor suite - this plugin, the JetBrains IDE plugin, and the shared
`markdown-table-core` library now all ship as `GPL-3.0-or-later` under one version number.

## Checksums

| Platform | SHA-256 of the pluginadmin ZIP |
| --- | --- |
| x86 | `8d5b66e539cceef2bce664433616eacdf57c22cbd590d155f11c5d6266877bf5` |
| x64 | `a39a5f4cce2b726c585b80d142c755b1d2cd7cd3ef8c1afe6e3be41c0ff5fa40` |
| arm64 | `37ed2e3ac28b514d3267e9bcd0cca18683d67ae817075e9f91a5b944c78e18ea` |

They match the `SHA256SUMS.txt` published with the release, and each ZIP carries a
`MarkdownTableEditor.dll` with file version `11.1.0.0`.