### PR TITLE
Retry transient download failures in the validator

### DIFF
--- a/validator.py
+++ b/validator.py
@@ -10,10 +10,25 @@ from urllib.parse import unquote as unquote_url
 
 import requests
 from jsonschema import Draft202012Validator, FormatChecker
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 from win32api import GetFileVersionInfo, LOWORD, HIWORD, error as win32api_error
 
 api_url = os.environ.get('APPVEYOR_API_URL')
 has_error = False
+
+# Every run downloads the archive of every plugin in the list, so a single transient hiccup on any
+# entry - a dropped connection, a gateway timeout - fails the whole validation and hides the real
+# result. Retry those, and give up only when a host is genuinely unreachable.
+DOWNLOAD_TIMEOUT_SECONDS = 60
+DOWNLOAD_RETRIES = Retry(
+    total=3,
+    backoff_factor=2,
+    status_forcelist=(408, 425, 429, 500, 502, 503, 504),
+    allowed_methods=frozenset(['GET']),
+    # Let the existing status code check report a persistent failure with its own message.
+    raise_on_status=False,
+)
 
 # Constants for creating the plugin list overview
 C_LINE_BREAK = '\x0d'
@@ -36,6 +51,14 @@ def get_version_number(filename):
     ms = info['FileVersionMS']
     ls = info['FileVersionLS']
     return '.'.join(map(str, [HIWORD(ms), LOWORD(ms), HIWORD(ls), LOWORD(ls)]))
+
+
+def create_download_session():
+    session = requests.Session()
+    adapter = HTTPAdapter(max_retries=DOWNLOAD_RETRIES)
+    session.mount('https://', adapter)
+    session.mount('http://', adapter)
+    return session
 
 
 def post_error(message):
@@ -182,6 +205,7 @@ def parse(filename):
         shutil.rmtree("./" + provided_architecture, True)
 
     os.mkdir("./" + provided_architecture)
+    download_session = create_download_session()
     for plugin in pl["npp-plugins"]:
         print(plugin["display-name"], end='')
 
@@ -201,7 +225,10 @@ def parse(filename):
             print(f' *** {"; ".join(compatibility_messages)} ***')
 
         try:
-            response = requests.get(unquote_url(plugin["repository"]))
+            response = download_session.get(
+                unquote_url(plugin["repository"]),
+                timeout=DOWNLOAD_TIMEOUT_SECONDS,
+            )
         except requests.exceptions.RequestException as e:
             post_error(f'{plugin["display-name"]}: {str(e)}')
             continue


### PR DESCRIPTION
`validator.py` downloads the archive of **every** plugin in the list on every run, with a single
`requests.get` that has no retries and no timeout. One dropped connection on any single entry —
including entries the pull request never touched — fails the whole job and hides the real result.

This is not hypothetical: in [run 30290736279](https://github.com/notepad-plus-plus/nppPluginList/actions/runs/30290736279/job/90059603529)
the `build (Release, x64)` job lost four unrelated plugins at once:

```
CS-Script - C# Intellisense: ('Connection aborted.', ConnectionResetError(10054, ...))
Markdown Table Editor:       ('Connection aborted.', ConnectionResetError(10054, ...))
NppEventExec:                ('Connection aborted.', ConnectionResetError(10054, ...))
pycalc:                      ('Connection aborted.', ConnectionResetError(10054, ...))
```

All four are hosted on the GitHub release CDN, the job died in `Validate json` before MSBuild ever
ran, and `build (Release, Win32)` and `build (Release, arm64)` validated the very same JSON files
successfully in the same run. Only a maintainer can re-run the job, so a contributor is stuck
looking at a red check they cannot clear or explain.

## Change

Downloads go through a `requests.Session` whose adapter retries connection errors and the usual
transient status codes (408, 425, 429, 500, 502, 503, 504) three times with exponential backoff,
plus a 60 second timeout so a hung host cannot stall the job indefinitely.

Error reporting is deliberately unchanged for real failures. `raise_on_status=False` keeps a
persistently non-200 response flowing into the existing status check with its original message, and
a host that stays unreachable still raises `RequestException` into the existing handler.

Worst case cost is bounded: a genuinely dead URL now takes about 12 extra seconds before it is
reported, and a healthy list costs nothing.

## Verification

Against a local server that injects faults, using the session built by this change:

| Scenario | Attempts | Outcome |
| --- | ---: | --- |
| clean download | 1 | 200 |
| 2 connection resets, then 200 | 3 | 200 |
| 2 gateway timeouts, then 200 | 3 | 200 |
| reset + 504, then 200 | 3 | 200 |
| resets past the budget | 4 | `ConnectionError` raised, reported as before |
| 504 past the budget | 4 | 504 preserved, reported as before |

The connection resets are real RSTs (`SO_LINGER` with a zero timeout), matching the WinError 10054
the runner saw.

`python validator.py x86`, `x64` and `arm64` all exit 0 against current `master` with this change,
with zero errors reported.

No new dependencies: `requests.adapters.HTTPAdapter` ships with `requests`, and `urllib3` is already
pinned in `requirements.txt`.