### PR TITLE
Add GitHub Repo Viewer (x64)

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -610,6 +610,16 @@
 			"homepage": "https://sourceforge.net/projects/gedcomlexer/"
 		},
 		{
+			"folder-name": "GitHubRepoViewer",
+			"display-name": "GitHub Repo Viewer",
+			"version": "1.2",
+			"id": "c9a8effae062cb6df35111fd5293ab9c1f024ce029ce8b5bde475d9a46917419",
+			"repository": "https://github.com/ufoptg/GitHubRepoViewer/releases/download/v1.2/GitHubRepoViewer.zip",
+			"description": "Browse all your GitHub repositories in a docked tree, open files, and push edits back on save.",
+			"author": "TrueSaiyan",
+			"homepage": "https://github.com/ufoptg/GitHubRepoViewer"
+		},
+		{
 			"folder-name": "GitSCM",
 			"display-name": "GitSCM",
 			"version": "1.4.10.1",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -612,7 +612,7 @@
 		{
 			"folder-name": "GitHubRepoViewer",
 			"display-name": "GitHub Repo Viewer",
-			"version": "1.2",
+			"version": "1.1",
 			"id": "c9a8effae062cb6df35111fd5293ab9c1f024ce029ce8b5bde475d9a46917419",
 			"repository": "https://github.com/ufoptg/GitHubRepoViewer/releases/download/v1.2/GitHubRepoViewer.zip",
 			"description": "Browse all your GitHub repositories in a docked tree, open files, and push edits back on save.",


### PR DESCRIPTION
## Plugin: GitHub Repo Viewer

Adds a new entry to `pl.x64.json` for **GitHub Repo Viewer**.

**What it does**
A docked side panel that lists all GitHub repositories your Personal Access Token can access
(like a file explorer). Expand a repo to browse its files, double-click to open a file in
Notepad++, and save (Ctrl+S) to push the change back via the GitHub Contents API. Features
repo/folder/file icons, a live filter box, tooltips + horizontal scroll for long names, a
right-click menu (copy path / raw URL), and it remembers expanded repos and the last filter
between sessions.

**Links**
- Source & README: https://github.com/ufoptg/GitHubRepoViewer
- Release (v1.2): https://github.com/ufoptg/GitHubRepoViewer/releases/tag/v1.2
- Download ZIP: https://github.com/ufoptg/GitHubRepoViewer/releases/download/v1.2/GitHubRepoViewer.zip

**Entry details**
- `folder-name`: GitHubRepoViewer
- `display-name`: GitHub Repo Viewer
- `version`: 1.2
- Architecture: **x64 only** (`pl.x64.json`)
- ZIP layout: `GitHubRepoViewer.dll` at the root of the ZIP
- SHA-256 (`id`): `c9a8effae062cb6df35111fd5293ab9c1f024ce029ce8b5bde475d9a46917419`

**Checklist**
- [x] Entry added to `pl.x64.json`, alphabetically ordered by `folder-name`
- [x] File kept as UTF-8 with BOM; JSON validates
- [x] ZIP contains the DLL at its root; DLL name matches `folder-name`
- [x] `id` is the SHA-256 of the exact released ZIP; `repository` URL is a direct download
- [x] Plugin verified to install, update, and uninstall via Plugins Admin locally
- [x] Source is public with a README and an open-source license

Thanks for reviewing! Happy to make any changes you suggest.