### PR TITLE
Add Dual Scrollbars 1.0.0 to x64 plugin list

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -445,7 +445,7 @@
 		    "description": "A simple Notepad++ plugin that adds a second vertical scrollbar with mirrored line numbers and markers.",
 		    "author": "SaiyajinK",
 		    "homepage": "https://github.com/SaiyajinK/Dual-Scrollbars-for-Notepad-Plus-Plus"
-		}
+		},
 		{
 			"folder-name": "NppEditorConfig",
 			"display-name": "EditorConfig",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -437,6 +437,16 @@
 			"homepage": "https://github.com/Predelnik/DSpellCheck"
 		},
 		{
+		    "folder-name": "DualScrollbars",
+		    "display-name": "Dual Scrollbars",
+		    "version": "1.0.0",
+		    "id": "811b53ca903ef1ee2b483df663bd755c524b03ed8f2f78eadd8d845c3933c956",
+		    "repository": "https://github.com/SaiyajinK/Dual-Scrollbars-for-Notepad-Plus-Plus/releases/download/v1.0.0/Dual-Scrollbars-v1.0.0-x64.zip",
+		    "description": "A simple Notepad++ plugin that adds a second vertical scrollbar with mirrored line numbers and markers.",
+		    "author": "SaiyajinK",
+		    "homepage": "https://github.com/SaiyajinK/Dual-Scrollbars-for-Notepad-Plus-Plus"
+		}
+		{
 			"folder-name": "NppEditorConfig",
 			"display-name": "EditorConfig",
 			"version": "0.4.0",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -441,7 +441,7 @@
 		    "display-name": "Dual Scrollbars",
 		    "version": "1.0.0",
 		    "id": "811b53ca903ef1ee2b483df663bd755c524b03ed8f2f78eadd8d845c3933c956",
-		    "repository": "https://github.com/SaiyajinK/Dual-Scrollbars-for-Notepad-Plus-Plus/releases/download/v1.0.0/Dual-Scrollbars-v1.0.0-x64.zip",
+		    "repository": "https://github.com/SaiyajinK/Dual-Scrollbars-for-Notepad-Plus-Plus/releases/download/1.0.0/Dual-Scrollbars-v1.0.0-x64.zip",
 		    "description": "A simple Notepad++ plugin that adds a second vertical scrollbar with mirrored line numbers and markers.",
 		    "author": "SaiyajinK",
 		    "homepage": "https://github.com/SaiyajinK/Dual-Scrollbars-for-Notepad-Plus-Plus"


### PR DESCRIPTION
## 🔌 Plugin : Dual Scrollbars

Adds a new entry to `pl.x64.json` for **Dual Scrollbars**.

### 🧩 What it does :

A lightweight Notepad++ plugin that adds a second vertical scrollbar to the left side of the editor while keeping the native scrollbar on the right.

It also mirrors the native editor margins on the opposite side, including line numbers, bookmarks, fold markers and change-history markers. Split view is supported.

### 🔗 Links :

- Source & README: https://github.com/SaiyajinK/Dual-Scrollbars-for-Notepad-Plus-Plus
- Release (v1.0.0): https://github.com/SaiyajinK/Dual-Scrollbars-for-Notepad-Plus-Plus/releases/tag/1.0.0
- Download ZIP: https://github.com/SaiyajinK/Dual-Scrollbars-for-Notepad-Plus-Plus/releases/download/1.0.0/Dual-Scrollbars-v1.0.0-x64.zip

### 📋 Entry details :

- `folder-name` : `DualScrollbars`
- `display-name` : `Dual Scrollbars`
- `version` : `1.0.0`
- `Architecture` : `x64 only (pl.x64.json)`
- `ZIP layout` : `DualScrollbars.dll` at the root of the ZIP
- `DLL file version` : `1.0.0.0`
- `SHA-256 (id)` : `811b53ca903ef1ee2b483df663bd755c524b03ed8f2f78eadd8d845c3933c956`

### ✅ Checklist :

- [x] Entry added to `pl.x64.json`, alphabetically ordered by `folder-name`
- [x] JSON successfully loaded using the Notepad++ debug build
- [x] Plugin appears correctly in Plugins Admin
- [x] ZIP contains `DualScrollbars.dll` at its root
- [x] DLL name matches `folder-name`
- [x] `id` is the SHA-256 of the exact release ZIP
- [x] `repository` URL downloads the ZIP directly
- [x] DLL contains version information matching `1.0.0`
- [x] Source repository is public and contains a README