### PR TITLE
Add GraphBuilder 1.3.2 (x64)

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -637,7 +637,7 @@
 			"version": "1.3.0",
 			"id": "19f2d1651d5dcbf52417a61e9219dee65ae2b07ea7337736487878b110a3a291",
 			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.3.0/GraphBuilder-npp-1.3.0-win64.zip",
-			"description": "A docked panel that plots the formula under your mouse: roots, intersections, extrema, a report, and a formula fitted to pasted data.",
+			"description": "[Requires the WebView2 runtime, which ships with Windows 11 and arrives with Edge on Windows 10]\r\nA docked panel that plots the formula under your mouse: roots, intersections, extrema, a report, and a formula fitted to pasted data.",
 			"author": "Yuriy Pisarev",
 			"homepage": "https://github.com/pisarev/graphbuilder-npp"
 		},

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -633,11 +633,11 @@
 		},
 		{
 			"folder-name": "GraphBuilderLaz",
-			"display-name": "GraphBuilder",
-			"version": "1.2.1",
-			"id": "377a4f79dd0c213cba7628944b8315bb31741f96a0eb853d85b3e18cb267e29c",
-			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.2.1/GraphBuilder-npp-1.2.1-win64.zip",
-			"description": "[Requires the WebView2 runtime, which ships with Windows 11 and arrives with Edge on Windows 10]\r\nPlots the formula under your mouse. Press Alt+G for the docked panel, then point at a line: if it parses as a formula, the curve appears with its roots, intersections and extrema marked. A selection wins over the line, and what comes from the editor keeps one slot of its own, so pointing around does not fill the list. The report goes back the other way - to a new tab as Markdown with the curve embedded as SVG, or straight at the caret. Cartesian and polar systems, several curves at once. The panel is a web page and the computing is Object Pascal, so the same page runs as a browser demo with the engine compiled to WebAssembly.",
+			"display-name": "Graph Builder",
+			"version": "1.3.0",
+			"id": "19f2d1651d5dcbf52417a61e9219dee65ae2b07ea7337736487878b110a3a291",
+			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.3.0/GraphBuilder-npp-1.3.0-win64.zip",
+			"description": "A docked panel that plots the formula under your mouse: roots, intersections, extrema, a report, and a formula fitted to pasted data.",
 			"author": "Yuriy Pisarev",
 			"homepage": "https://github.com/pisarev/graphbuilder-npp"
 		},

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -632,6 +632,16 @@
 			"homepage": "https://github.com/shriprem/Goto-Line-Col-NPP-Plugin"
 		},
 		{
+			"folder-name": "GraphBuilderLaz",
+			"display-name": "GraphBuilder",
+			"version": "1.0.7",
+			"id": "42b8f422c21717783a43d86f4c87fa511703c808e4012204419533d80771ff54",
+			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.0.7/GraphBuilder-npp-1.0.7-win64.zip",
+			"description": "[Requires the WebView2 runtime, which ships with Windows 11 and arrives with Edge on Windows 10]\r\nPlots the formula under your mouse. Press Alt+G for the docked panel, then point at a line: if it parses as a formula, the curve appears with its roots, intersections and extrema marked. A selection wins over the line, and what comes from the editor keeps one slot of its own, so pointing around does not fill the list. The report goes back the other way - to a new tab as Markdown with the curve embedded as SVG, or straight at the caret. Cartesian and polar systems, several curves at once. The panel is a web page and the computing is Object Pascal, so the same page runs as a browser demo with the engine compiled to WebAssembly.",
+			"author": "Yuriy Pisarev",
+			"homepage": "https://github.com/pisarev/graphbuilder-npp"
+		},
+		{
 			"folder-name": "HexEditor",
 			"display-name": "HEX-Editor",
 			"version": "0.9.14.0",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -634,9 +634,9 @@
 		{
 			"folder-name": "GraphBuilderLaz",
 			"display-name": "Graph Builder",
-			"version": "1.3.0",
-			"id": "19f2d1651d5dcbf52417a61e9219dee65ae2b07ea7337736487878b110a3a291",
-			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.3.0/GraphBuilder-npp-1.3.0-win64.zip",
+			"version": "1.3.2",
+			"id": "10d8323e5d3f773734dd43df0265e582d1f36e794c8bae4a90db4b98662a721f",
+			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.3.2/GraphBuilder-npp-1.3.2-win64.zip",
 			"description": "[Requires the WebView2 runtime, which ships with Windows 11 and arrives with Edge on Windows 10]\r\nA docked panel that plots the formula under your mouse: roots, intersections, extrema, a report, and a formula fitted to pasted data.",
 			"author": "Yuriy Pisarev",
 			"homepage": "https://github.com/pisarev/graphbuilder-npp"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -634,9 +634,9 @@
 		{
 			"folder-name": "GraphBuilderLaz",
 			"display-name": "GraphBuilder",
-			"version": "1.0.7",
-			"id": "42b8f422c21717783a43d86f4c87fa511703c808e4012204419533d80771ff54",
-			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.0.7/GraphBuilder-npp-1.0.7-win64.zip",
+			"version": "1.1.1",
+			"id": "bfc3b459c95d0e318a57c2a95d10be7351b2504fb14193ae0a286590810e897f",
+			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.1.1/GraphBuilder-npp-1.1.1-win64.zip",
 			"description": "[Requires the WebView2 runtime, which ships with Windows 11 and arrives with Edge on Windows 10]\r\nPlots the formula under your mouse. Press Alt+G for the docked panel, then point at a line: if it parses as a formula, the curve appears with its roots, intersections and extrema marked. A selection wins over the line, and what comes from the editor keeps one slot of its own, so pointing around does not fill the list. The report goes back the other way - to a new tab as Markdown with the curve embedded as SVG, or straight at the caret. Cartesian and polar systems, several curves at once. The panel is a web page and the computing is Object Pascal, so the same page runs as a browser demo with the engine compiled to WebAssembly.",
 			"author": "Yuriy Pisarev",
 			"homepage": "https://github.com/pisarev/graphbuilder-npp"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -634,9 +634,9 @@
 		{
 			"folder-name": "GraphBuilderLaz",
 			"display-name": "GraphBuilder",
-			"version": "1.1.1",
-			"id": "bfc3b459c95d0e318a57c2a95d10be7351b2504fb14193ae0a286590810e897f",
-			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.1.1/GraphBuilder-npp-1.1.1-win64.zip",
+			"version": "1.2.0",
+			"id": "87212290109277112a5b047c152d6985ff93c8186f759b55c0deb04ace0fd327",
+			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.2.0/GraphBuilder-npp-1.2.0-win64.zip",
 			"description": "[Requires the WebView2 runtime, which ships with Windows 11 and arrives with Edge on Windows 10]\r\nPlots the formula under your mouse. Press Alt+G for the docked panel, then point at a line: if it parses as a formula, the curve appears with its roots, intersections and extrema marked. A selection wins over the line, and what comes from the editor keeps one slot of its own, so pointing around does not fill the list. The report goes back the other way - to a new tab as Markdown with the curve embedded as SVG, or straight at the caret. Cartesian and polar systems, several curves at once. The panel is a web page and the computing is Object Pascal, so the same page runs as a browser demo with the engine compiled to WebAssembly.",
 			"author": "Yuriy Pisarev",
 			"homepage": "https://github.com/pisarev/graphbuilder-npp"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -634,9 +634,9 @@
 		{
 			"folder-name": "GraphBuilderLaz",
 			"display-name": "GraphBuilder",
-			"version": "1.2.0",
-			"id": "87212290109277112a5b047c152d6985ff93c8186f759b55c0deb04ace0fd327",
-			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.2.0/GraphBuilder-npp-1.2.0-win64.zip",
+			"version": "1.2.1",
+			"id": "377a4f79dd0c213cba7628944b8315bb31741f96a0eb853d85b3e18cb267e29c",
+			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.2.1/GraphBuilder-npp-1.2.1-win64.zip",
 			"description": "[Requires the WebView2 runtime, which ships with Windows 11 and arrives with Edge on Windows 10]\r\nPlots the formula under your mouse. Press Alt+G for the docked panel, then point at a line: if it parses as a formula, the curve appears with its roots, intersections and extrema marked. A selection wins over the line, and what comes from the editor keeps one slot of its own, so pointing around does not fill the list. The report goes back the other way - to a new tab as Markdown with the curve embedded as SVG, or straight at the caret. Cartesian and polar systems, several curves at once. The panel is a web page and the computing is Object Pascal, so the same page runs as a browser demo with the engine compiled to WebAssembly.",
 			"author": "Yuriy Pisarev",
 			"homepage": "https://github.com/pisarev/graphbuilder-npp"


### PR DESCRIPTION
GraphBuilder plots the formula under your mouse. Alt+G opens a docked panel;
point at a line of the file and, if it parses as a formula, the curve is drawn
with its roots, intersections and extrema marked. A selection wins over the
line, and whatever comes from the editor keeps a slot of its own, so pointing
around does not fill up the list.

The report goes back the other way: one button puts it in a new tab as Markdown,
with the curve embedded as SVG so it stays text in a text editor, and another
drops the same report at the caret.

The panel is a web page in WebView2 and the computing is Object Pascal. The same
page runs as a [browser demo](https://pisarev.github.io/mathparser-live/demo/)
with the engine compiled to WebAssembly, so the plugin can be tried without
installing it.

Built with Lazarus and Free Pascal; the sources and the build script are in the
repository, so the DLL can be reproduced without a commercial compiler.

- x64 only.
- Requires the WebView2 runtime: it ships with Windows 11 and arrives with Edge
  on Windows 10.
- Installed and used locally on Notepad++ 8.9.3, 64-bit: the panel opens, picks
  a formula off a line, draws it, and returns the report to the editor both ways.

Archive: https://github.com/pisarev/graphbuilder-npp/releases/download/v1.0.7/GraphBuilder-npp-1.0.7-win64.zip
sha256: 42b8f422c21717783a43d86f4c87fa511703c808e4012204419533d80771ff54