### PR TITLE
Update Emoji Description to version 0.4.17

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -81,10 +81,10 @@
 		{
 			"folder-name": "EmojiDescription",
 			"display-name": "Emoji Description",
-			"version": "0.3.16",
-			"id": "293bcb62c8cbc389e8552a6eeae34dcd013402322c60da6094f107c767109d1f",
-			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.3.16/EmojiDescription_arm64_v0.3.16.zip",
-			"description": "Displays detailed character encoding information in the status bar. Shows Unicode code point, decimal/hexadecimal values, HTML entity, and UTF-8 byte sequence for any character including emoji.",
+			"version": "0.4.17",
+			"id": "e9ad7776551c1d8e5b8a601de239b553516c054fcb6dc7acc4cf0d4a25ec1e4c",
+			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.4.17/EmojiDescription_arm64_v0.4.17.zip",
+			"description": "Displays detailed character encoding information in the status bar: Unicode code point, character name, HTML entity, and the UTF-8 byte sequence in hexadecimal, decimal or git-style octal notation. A menu command opens a dialog with every field for the character at the caret, ready to copy to the clipboard. Works for any character including emoji.",
 			"author": "Ruberoid",
 			"homepage": "https://github.com/Ruberoid/npp_emoji_description"
 		},

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -461,10 +461,10 @@
 		{
 			"folder-name": "EmojiDescription",
 			"display-name": "Emoji Description",
-			"version": "0.3.16",
-			"id": "62102bba90ef9b9e58c832fe3c5a67e4dffce5e18389ddf931c4ae0471675ddc",
-			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.3.16/EmojiDescription_x64_v0.3.16.zip",
-			"description": "Displays detailed character encoding information in the status bar. Shows Unicode code point, decimal/hexadecimal values, HTML entity, and UTF-8 byte sequence for any character including emoji.",
+			"version": "0.4.17",
+			"id": "ac24918ad416ec81d74ca4d8e12bd1e87a84c232509df92b633a0808918df28e",
+			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.4.17/EmojiDescription_x64_v0.4.17.zip",
+			"description": "Displays detailed character encoding information in the status bar: Unicode code point, character name, HTML entity, and the UTF-8 byte sequence in hexadecimal, decimal or git-style octal notation. A menu command opens a dialog with every field for the character at the caret, ready to copy to the clipboard. Works for any character including emoji.",
 			"author": "Ruberoid",
 			"homepage": "https://github.com/Ruberoid/npp_emoji_description"
 		},

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -437,10 +437,10 @@
 		{
 			"folder-name": "EmojiDescription",
 			"display-name": "Emoji Description",
-			"version": "0.3.16",
-			"id": "b84c19588bbed9ff04d26d0f998b7835c2ed4468942f9355ad4e205c523168b8",
-			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.3.16/EmojiDescription_x86_v0.3.16.zip",
-			"description": "Displays detailed character encoding information in the status bar. Shows Unicode code point, decimal/hexadecimal values, HTML entity, and UTF-8 byte sequence for any character including emoji.",
+			"version": "0.4.17",
+			"id": "c5a379d5014174e083e21ab29ee0d865485c82eed4a12cc2f1d8ab943f9f048a",
+			"repository": "https://github.com/Ruberoid/npp_emoji_description/releases/download/v0.4.17/EmojiDescription_x86_v0.4.17.zip",
+			"description": "Displays detailed character encoding information in the status bar: Unicode code point, character name, HTML entity, and the UTF-8 byte sequence in hexadecimal, decimal or git-style octal notation. A menu command opens a dialog with every field for the character at the caret, ready to copy to the clipboard. Works for any character including emoji.",
 			"author": "Ruberoid",
 			"homepage": "https://github.com/Ruberoid/npp_emoji_description"
 		},


### PR DESCRIPTION
Updates the `EmojiDescription` entry in `pl.x64.json`, `pl.x86.json` and `pl.arm64.json` to 0.4.17.

Release: https://github.com/Ruberoid/npp_emoji_description/releases/tag/v0.4.17

| arch | SHA-256 of the ZIP |
|---|---|
| x64 | `ac24918ad416ec81d74ca4d8e12bd1e87a84c232509df92b633a0808918df28e` |
| x86 | `c5a379d5014174e083e21ab29ee0d865485c82eed4a12cc2f1d8ab943f9f048a` |
| arm64 | `e9ad7776551c1d8e5b8a601de239b553516c054fcb6dc7acc4cf0d4a25ec1e4c` |

What is new in this release:

- The UTF-8 byte sequence can now also be shown in decimal, and in the backslash-escaped octal notation `git status` uses for non-ASCII bytes in paths (`Т` → `\320\242`).
- A new `Copy character details...` menu command opens a dialog listing every field for the character at the caret and copies the block to the clipboard.
- The status-bar fields were reorganized so that the hexadecimal, decimal and octal fields all describe the same UTF-8 byte sequence, rather than a mix of bytes and code point.

The `description` field was refreshed to match; the only lines touched in each file are `version`, `id`, `repository` and `description` inside the `EmojiDescription` block.