### PR TITLE
Add NppTranslatePanel 0.1.0

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1340,6 +1340,17 @@
 			"homepage": "https://github.com/KubaDee/NppTextViz"
 		},
 		{
+			"folder-name": "NppTranslatePanel",
+			"display-name": "NppTranslatePanel",
+			"version": "0.1.0.0",
+			"npp-compatible-versions": "[8.0,]",
+			"id": "d387ba96d978949af7006d5081350da0f1eecca6e83d8deb0de344c42dd2d89c",
+			"repository": "https://github.com/Jerryk133/NppTranslatePanel/releases/download/v0.1.0/NppTranslatePanel-0.1.0-x64.zip",
+			"description": "[Requires .NET Framework 4.8] Live-translates the active document in a synchronized dockable panel. Supports DeepL (user API key required) and MyMemory.",
+			"author": "Jerryk133",
+			"homepage": "https://github.com/Jerryk133/NppTranslatePanel"
+		},
+		{
 			"folder-name": "NppUISpy",
 			"display-name": "NppUISpy",
 			"version": "1.2",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1361,6 +1361,17 @@
 			"homepage": "https://github.com/KubaDee/NppTextViz"
 		},
 		{
+			"folder-name": "NppTranslatePanel",
+			"display-name": "NppTranslatePanel",
+			"version": "0.1.0.0",
+			"npp-compatible-versions": "[8.0,]",
+			"id": "712370879fac2a6ef748418321d9b10013761fe919136341d770cc56cdac8ea5",
+			"repository": "https://github.com/Jerryk133/NppTranslatePanel/releases/download/v0.1.0/NppTranslatePanel-0.1.0-x86.zip",
+			"description": "[Requires .NET Framework 4.8] Live-translates the active document in a synchronized dockable panel. Supports DeepL (user API key required) and MyMemory.",
+			"author": "Jerryk133",
+			"homepage": "https://github.com/Jerryk133/NppTranslatePanel"
+		},
+		{
 			"folder-name": "NppUISpy",
 			"display-name": "NppUISpy",
 			"version": "1.2",


### PR DESCRIPTION
Adds NppTranslatePanel 0.1.0 to the x64 and x86 plugin catalogs.\n\nNppTranslatePanel provides live translation of the active Notepad++ document in a synchronized dockable panel. It supports DeepL and MyMemory and requires .NET Framework 4.8.\n\nRelease: https://github.com/Jerryk133/NppTranslatePanel/releases/tag/v0.1.0

Validation: both x64 and x86 packages pass the repository's official validator.