### PR TITLE
Update TidyText to 1.1.0, add Win32 and ARM64 builds

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -507,6 +507,16 @@
 			"homepage": "https://github.com/bsagarzazu/npp-tc-syslog-finder"
 		},
 		{
+			"folder-name": "TidyText",
+			"display-name": "TidyText",
+			"version": "1.1.0.0",
+			"id": "3fc684e1fbae22bf22775fdb1e5ad6133c772666a1fde97c2f777dd0d78bce50",
+			"repository": "https://github.com/gonzalu/TidyText/releases/download/v1.1.0/TidyText_ARM64.zip",
+			"description": "Highlights and repairs non-printing and mis-encoded (mojibake) characters, including curly quotes, dashes, NBSP, zero-width spaces, BOM, and UTF-8-as-Latin-1 corruption. Also sends the current selection to ChatGPT, Claude, or Gemini via the clipboard and your default browser.",
+			"author": "gonzalu",
+			"homepage": "https://github.com/gonzalu/TidyText"
+		},
+		{
 			"folder-name": "TopMost",
 			"display-name": "TopMost",
 			"version": "1.4.2.0",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1862,9 +1862,9 @@
 		{
 			"folder-name": "TidyText",
 			"display-name": "TidyText",
-			"version": "1.0.0.0",
-			"id": "ac6e421c0f4032c6f403b6737c1eab26a1dedaf915f26faf3b1a9c15e892bc27",
-			"repository": "https://github.com/gonzalu/TidyText/releases/download/v1.0.0/TidyText_x64_1.0.0.zip",
+			"version": "1.1.0.0",
+			"id": "12dd477e471afd0e99754c9fe1853e1956849de1718eba692d6f9cf2b0ab603e",
+			"repository": "https://github.com/gonzalu/TidyText/releases/download/v1.1.0/TidyText_x64.zip",
 			"description": "Highlights and repairs non-printing and mis-encoded (mojibake) characters, including curly quotes, dashes, NBSP, zero-width spaces, BOM, and UTF-8-as-Latin-1 corruption. Also sends the current selection to ChatGPT, Claude, or Gemini via the clipboard and your default browser.",
 			"author": "gonzalu",
 			"homepage": "https://github.com/gonzalu/TidyText"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1903,6 +1903,16 @@
 			"homepage": "https://code.google.com/p/npp-tidy2/"
 		},
 		{
+			"folder-name": "TidyText",
+			"display-name": "TidyText",
+			"version": "1.1.0.0",
+			"id": "d997a31500c2a135694c6b4403241658f17d944459a129fe3dd1fefb31434df4",
+			"repository": "https://github.com/gonzalu/TidyText/releases/download/v1.1.0/TidyText_Win32.zip",
+			"description": "Highlights and repairs non-printing and mis-encoded (mojibake) characters, including curly quotes, dashes, NBSP, zero-width spaces, BOM, and UTF-8-as-Latin-1 corruption. Also sends the current selection to ChatGPT, Claude, or Gemini via the clipboard and your default browser.",
+			"author": "gonzalu",
+			"homepage": "https://github.com/gonzalu/TidyText"
+		},
+		{
 			"folder-name": "NppToolBucket",
 			"display-name": "ToolBucket",
 			"version": "1.10.6622.41336",


### PR DESCRIPTION
Follow-up to #1154 — per @chcg's request, TidyText now ships Win32
and ARM64 builds in addition to x64, all built and published
automatically via GitHub Actions on tag push:
https://github.com/gonzalu/TidyText/blob/master/.github/workflows/build.yml

Changes:
- Updated the existing pl.x64.json entry to v1.1.0
- Added matching entries to pl.x86.json and pl.arm64.json

Release: https://github.com/gonzalu/TidyText/releases/tag/v1.1.0

Locally validated all three entries (schema, hash, zip contents, and
embedded DLL version) before submitting, same as the first PR.