### PR TITLE
Add NppImagePreview

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1240,7 +1240,7 @@
         "folder-name": "NppImagePreview",
         "display-name": "NppImagePreview",
         "version": "1.0.0",
-        "id": "8492449a2679d641dd8555df0c5fb4e09e2446398ee123216aae0e96f8cc4fdd",
+        "id": "7a6c8d01d391162999d820438b9bfd4c8218644fd78787bb0af6609c2ad11d20",
         "repository": "https://github.com/bdgeek/NppImagePreview/releases/download/v1.0.0/NppImagePreview-v1.0.0-x64.zip",
         "description": "Preview images referenced in HTML, CSS, PHP, and JavaScript files directly in Notepad++. Hover over an image path to display a thumbnail preview, or use Preview Image at Cursor. Supports PNG, JPG, WebP, GIF, SVG, BMP, ICO, AVIF, and TIFF.",
         "author": "Mashkawat Ahsan",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1237,6 +1237,16 @@
 			"homepage": "https://github.com/Pascal-Krenckel/NppGZipFileViewer"
 		},
 		{
+        "folder-name": "NppImagePreview",
+        "display-name": "NppImagePreview",
+        "version": "1.0.0",
+        "id": "8492449a2679d641dd8555df0c5fb4e09e2446398ee123216aae0e96f8cc4fdd",
+        "repository": "https://github.com/bdgeek/NppImagePreview/releases/download/v1.0.0/NppImagePreview-v1.0.0-x64.zip",
+        "description": "Preview images referenced in HTML, CSS, PHP, and JavaScript files directly in Notepad++. Hover over an image path to display a thumbnail preview, or use Preview Image at Cursor. Supports PNG, JPG, WebP, GIF, SVG, BMP, ICO, AVIF, and TIFF.",
+        "author": "Mashkawat Ahsan",
+        "homepage": "https://github.com/bdgeek/NppImagePreview"
+        },
+		{
 			"folder-name": "NppJumpList",
 			"display-name": "NppJumpList",
 			"version": "1.2.2",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1240,7 +1240,7 @@
         "folder-name": "NppImagePreview",
         "display-name": "NppImagePreview",
         "version": "1.0.0",
-        "id": "7a6c8d01d391162999d820438b9bfd4c8218644fd78787bb0af6609c2ad11d20",
+        "id": "9db7e5d5693bea511c6ff015a2acc08bfb24ad650ccfdd893672adee38f5aa95",
         "repository": "https://github.com/bdgeek/NppImagePreview/releases/download/v1.0.0/NppImagePreview-v1.0.0-x64.zip",
         "description": "Preview images referenced in HTML, CSS, PHP, and JavaScript files directly in Notepad++. Hover over an image path to display a thumbnail preview, or use Preview Image at Cursor. Supports PNG, JPG, WebP, GIF, SVG, BMP, ICO, AVIF, and TIFF.",
         "author": "Mashkawat Ahsan",


### PR DESCRIPTION
## NppImagePreview

Add NppImagePreview to the Notepad++ Plugin Admin x64 plugin list.

NppImagePreview provides image preview functionality for image paths referenced in HTML, CSS, PHP, and JavaScript files.

### Release

- Version: 1.0.0
- Architecture: x64
- Release: https://github.com/bdgeek/NppImagePreview/releases/tag/v1.0.0
- SHA-256: 8492449a2679d641dd8555df0c5fb4e09e2446398ee123216aae0e96f8cc4fdd

The plugin has been tested successfully in Notepad++ before submission.