### PR TITLE
Update Graph Builder to 1.3.3

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -654,9 +654,9 @@
 		{
 			"folder-name": "GraphBuilderLaz",
 			"display-name": "Graph Builder",
-			"version": "1.3.2",
-			"id": "10d8323e5d3f773734dd43df0265e582d1f36e794c8bae4a90db4b98662a721f",
-			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.3.2/GraphBuilder-npp-1.3.2-win64.zip",
+			"version": "1.3.3",
+			"id": "1c143f67fbbb47d52b53b9d5da45dad3d9823a4776a6e9e4b2f9440e4be4a7d0",
+			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.3.3/GraphBuilder-npp-1.3.3-win64.zip",
 			"description": "[Requires the WebView2 runtime, which ships with Windows 11 and arrives with Edge on Windows 10]\r\nA docked panel that plots the formula under your mouse: roots, intersections, extrema, a report, and a formula fitted to pasted data.",
 			"author": "Yuriy Pisarev",
 			"homepage": "https://github.com/pisarev/graphbuilder-npp"


### PR DESCRIPTION
Updates Graph Builder from 1.3.2 to 1.3.3.

- version: 1.3.2 -> 1.3.3
- repository: the v1.3.3 release asset
- id: sha256 of GraphBuilder-npp-1.3.3-win64.zip

The archive carries GraphBuilderLaz.dll at its root, unchanged from the 1.3.2 entry.