### PR TITLE
Add OCaml Lexer (x64)

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1435,6 +1435,16 @@
 			"homepage": "https://github.com/ZhuXuefengGitHub/NX_ASCII_Database_Helper"
 		},
 		{
+			"folder-name": "OCamlLexer",
+			"display-name": "OCaml Lexer",
+			"version": "1.0.0",
+			"id": "20b136328f477e7ace3366b0ca87d6de61d61b384969f275f419a41d65e8a3be",
+			"repository": "https://github.com/Zaneham/ocaml-npp/releases/download/v1.0.0/OCamlLexer_x64.zip",
+			"description": "Syntax highlighting, folding and live linting for OCaml. A Scintilla ILexer5 lexer, so OCaml registers as a real language, with nested comments, quoted strings and char literals kept apart from type variables. Bundles the olint linter, which draws diagnostics inline on open and save.",
+			"author": "Zane Hambly",
+			"homepage": "https://github.com/Zaneham/ocaml-npp"
+		},
+		{
 			"folder-name": "nppplugin_ofis2",
 			"display-name": "Open File In Solution",
 			"version": "3.0.1",


### PR DESCRIPTION
Adds OCaml Lexer, a Scintilla/Lexilla ILexer5 lexer for OCaml with folding and live diagnostics. Notepad++'s built-in `caml` entry covers `.ml` and `.mli` with keyword highlighting only, so this adds nested comments, quoted strings, char literals kept apart from type variables, and `.mll` / `.mly` support. The zip bundles the olint linter next to the DLL so diagnostics work without any PATH setup. Tested locally on Notepad++ 8.x, and SHA-256 verified against the v1.0.0 release asset.