### PR TITLE
Add NppS3 1.0.0

### DIFF
--- a/src/pl.arm64.json
+++ b/src/pl.arm64.json
@@ -334,6 +334,16 @@
 			"homepage": "https://sourceforge.net/projects/npp-plugins/files/NppDocShare/"
 		},
 		{
+			"folder-name": "NppS3",
+			"display-name": "NppS3",
+			"version": "1.0.0",
+			"id": "68422319489f4fda7886902ad1576eddb79b95dc37db1c158c142052eeef6571",
+			"repository": "https://github.com/bsy0318/NppS3/releases/download/v1.0.0/NppS3-1.0.0-arm64.zip",
+			"description": "Browse and edit Amazon S3 and Cloudflare R2 objects from a docked panel. Open a remote object, edit it, and press Ctrl+S to upload it back.",
+			"author": "Seoyeon Bae",
+			"homepage": "https://github.com/bsy0318/NppS3"
+		},
+		{
 			"folder-name": "NppTextViz",
 			"display-name": "NppTextViz",
 			"version": "0.4.3",

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1341,6 +1341,16 @@
 			"homepage": "https://github.com/viper3400/RegExTractor/wiki/de_userdocumentation"
 		},
 		{
+			"folder-name": "NppS3",
+			"display-name": "NppS3",
+			"version": "1.0.0",
+			"id": "e0294f6c35bbf566629317fac7a4801198fb33247da4d932b145e06e2f1ee432",
+			"repository": "https://github.com/bsy0318/NppS3/releases/download/v1.0.0/NppS3-1.0.0-x64.zip",
+			"description": "Browse and edit Amazon S3 and Cloudflare R2 objects from a docked panel. Open a remote object, edit it, and press Ctrl+S to upload it back.",
+			"author": "Seoyeon Bae",
+			"homepage": "https://github.com/bsy0318/NppS3"
+		},
+		{
 			"folder-name": "NppStripIpAndHost",
 			"display-name": "NppStripIpAndHost",
 			"version": "1.0.0",

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1331,6 +1331,16 @@
 			"homepage": "https://github.com/viper3400/RegExTractor/wiki/de_userdocumentation"
 		},
 		{
+			"folder-name": "NppS3",
+			"display-name": "NppS3",
+			"version": "1.0.0",
+			"id": "0a23fe7b31b65fd055fcfb0f3c7568f02e18352c6540336ef8fe4d0679e5a66f",
+			"repository": "https://github.com/bsy0318/NppS3/releases/download/v1.0.0/NppS3-1.0.0-x86.zip",
+			"description": "Browse and edit Amazon S3 and Cloudflare R2 objects from a docked panel. Open a remote object, edit it, and press Ctrl+S to upload it back.",
+			"author": "Seoyeon Bae",
+			"homepage": "https://github.com/bsy0318/NppS3"
+		},
+		{
 			"folder-name": "NppTags",
 			"display-name": "NppTags",
 			"version": "0.9.1",


### PR DESCRIPTION
NppS3 is a Notepad++ plugin for Amazon S3 and Cloudflare R2.  
It adds a docked panel for browsing buckets and prefixes, opens remote objects in the editor, and uploads them back on `Ctrl+S'.  
  
- Homepage: https://github.com/bsy0318/NppS3  
- Release: https://github.com/bsy0318/NppS3/releases/tag/v1.0.0  
- License: GPL-3.0-or-later


### Entries

One entry added to each list, inserted in `display-name` order:

| List | Position | SHA-256 of the archive |
| --- | --- | --- |
| `pl.x64.json` | after `NppRegExTractor` | `e0294f6c35bbf566629317fac7a4801198fb33247da4d932b145e06e2f1ee432` |
| `pl.x86.json` | after `NppRegExTractor` | `0a23fe7b31b65fd055fcfb0f3c7568f02e18352c6540336ef8fe4d0679e5a66f` |
| `pl.arm64.json` | after `NppNetNote` | `68422319489f4fda7886902ad1576eddb79b95dc37db1c158c142052eeef6571` |

### Packaging

Each archive contains a single `NppS3.dll`, and the DLL file version is a `1.0.0.0` in all three builds.  
There is no external runtime dependency: the CRT is linked statically, networking uses WinHTTP, TLS uses Schannel and hashing
uses CNG.

### Testing

Tested locally with Notepad++ 8.9.1 against an S3-compatible endpoint: connect, browse prefixes, open a remote object, edit it, save with `Ctrl+S`, and confirm the uploaded object matches byte for byte.  