### PR TITLE
Update NppTranslatePanel to 0.3.0

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1383,10 +1383,10 @@
 		{
 			"folder-name": "NppTranslatePanel",
 			"display-name": "NppTranslatePanel",
-			"version": "0.1.0.0",
+			"version": "0.2.0.0",
 			"npp-compatible-versions": "[8.0,]",
-			"id": "d387ba96d978949af7006d5081350da0f1eecca6e83d8deb0de344c42dd2d89c",
-			"repository": "https://github.com/Jerryk133/NppTranslatePanel/releases/download/v0.1.0/NppTranslatePanel-0.1.0-x64.zip",
+			"id": "3e2904820b27e8ec665d86007dd82b890f6d8294e9f5f1f081ed256c6db0aa2b",
+			"repository": "https://github.com/Jerryk133/NppTranslatePanel/releases/download/v0.2.0/NppTranslatePanel-0.2.0-x64.zip",
 			"description": "[Requires .NET Framework 4.8] Live-translates the active document in a synchronized dockable panel. Supports DeepL (user API key required) and MyMemory.",
 			"author": "Jerryk133",
 			"homepage": "https://github.com/Jerryk133/NppTranslatePanel"

--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1383,11 +1383,11 @@
 		{
 			"folder-name": "NppTranslatePanel",
 			"display-name": "NppTranslatePanel",
-			"version": "0.2.0.0",
+			"version": "0.3.0.0",
 			"npp-compatible-versions": "[8.0,]",
-			"id": "3e2904820b27e8ec665d86007dd82b890f6d8294e9f5f1f081ed256c6db0aa2b",
-			"repository": "https://github.com/Jerryk133/NppTranslatePanel/releases/download/v0.2.0/NppTranslatePanel-0.2.0-x64.zip",
-			"description": "[Requires .NET Framework 4.8] Live-translates the active document in a synchronized dockable panel. Supports DeepL (user API key required) and MyMemory.",
+			"id": "49af02cb4d5925ebec1b98b3641bee726fbd0351d94c7438059707da7de5e763",
+			"repository": "https://github.com/Jerryk133/NppTranslatePanel/releases/download/v0.3.0/NppTranslatePanel-0.3.0-x64.zip",
+			"description": "[Requires .NET Framework 4.8] Translates selected text or the active document in a synchronized dockable panel. Supports DeepL (user API key required) and MyMemory.",
 			"author": "Jerryk133",
 			"homepage": "https://github.com/Jerryk133/NppTranslatePanel"
 		},

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1363,10 +1363,10 @@
 		{
 			"folder-name": "NppTranslatePanel",
 			"display-name": "NppTranslatePanel",
-			"version": "0.1.0.0",
+			"version": "0.2.0.0",
 			"npp-compatible-versions": "[8.0,]",
-			"id": "712370879fac2a6ef748418321d9b10013761fe919136341d770cc56cdac8ea5",
-			"repository": "https://github.com/Jerryk133/NppTranslatePanel/releases/download/v0.1.0/NppTranslatePanel-0.1.0-x86.zip",
+			"id": "e6da68dfa8d64045f574bcc9156a12b458fe155cded4ba312fa572478fdab008",
+			"repository": "https://github.com/Jerryk133/NppTranslatePanel/releases/download/v0.2.0/NppTranslatePanel-0.2.0-x86.zip",
 			"description": "[Requires .NET Framework 4.8] Live-translates the active document in a synchronized dockable panel. Supports DeepL (user API key required) and MyMemory.",
 			"author": "Jerryk133",
 			"homepage": "https://github.com/Jerryk133/NppTranslatePanel"

--- a/src/pl.x86.json
+++ b/src/pl.x86.json
@@ -1363,11 +1363,11 @@
 		{
 			"folder-name": "NppTranslatePanel",
 			"display-name": "NppTranslatePanel",
-			"version": "0.2.0.0",
+			"version": "0.3.0.0",
 			"npp-compatible-versions": "[8.0,]",
-			"id": "e6da68dfa8d64045f574bcc9156a12b458fe155cded4ba312fa572478fdab008",
-			"repository": "https://github.com/Jerryk133/NppTranslatePanel/releases/download/v0.2.0/NppTranslatePanel-0.2.0-x86.zip",
-			"description": "[Requires .NET Framework 4.8] Live-translates the active document in a synchronized dockable panel. Supports DeepL (user API key required) and MyMemory.",
+			"id": "438f14d2360dfaeb69ff198e56de6a75684d56dddeee3424e9245076114526e9",
+			"repository": "https://github.com/Jerryk133/NppTranslatePanel/releases/download/v0.3.0/NppTranslatePanel-0.3.0-x86.zip",
+			"description": "[Requires .NET Framework 4.8] Translates selected text or the active document in a synchronized dockable panel. Supports DeepL (user API key required) and MyMemory.",
 			"author": "Jerryk133",
 			"homepage": "https://github.com/Jerryk133/NppTranslatePanel"
 		},


### PR DESCRIPTION
Updates NppTranslatePanel in both plugin lists from 0.1.0.0 to 0.3.0.0.

- x64 and x86 release URLs point to GitHub release v0.3.0
- SHA-256 IDs match the published ZIP assets
- Description now reflects document and selection translation
- JSON syntax was validated locally for both plugin lists

Release: https://github.com/Jerryk133/NppTranslatePanel/releases/tag/v0.3.0