### PR TITLE
Add NppZenHankaku 1.0.0 (x64)

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -1121,6 +1121,17 @@
 			"homepage": "https://github.com/joaoasrosa/nppxmltreeview/"
 		},
 		{
+			"folder-name": "NppZenHankaku",
+			"display-name": "NppZenHankaku",
+			"version": "1.0.0",
+			"npp-compatible-versions": "[8.0,]",
+			"id": "f1dfe323bd9b17075138274e7ed2a6848d588a29e57da866186e3102c36f24d2",
+			"repository": "https://github.com/RivieraSystems/NppZenHankaku/releases/download/v1.0.0/NppZenHankaku_1.0.0_x64.zip",
+			"description": "Convert between full-width (zenkaku) and half-width (hankaku) characters: alphanumerics, katakana, symbols, and spaces. Supports multiple and rectangular selections.",
+			"author": "RivieraSystems",
+			"homepage": "https://github.com/RivieraSystems/NppZenHankaku"
+		},
+		{
 			"folder-name": "npp.connections",
 			"display-name": "npp.Connections",
 			"version": "1.1.0",


### PR DESCRIPTION
## Plugin: NppZenHankaku

Adds an entry to `pl.x64.json` for **NppZenHankaku**.

### What it does

Notepad++ plugin to convert between full-width (zenkaku) and half-width (hankaku) characters (alphanumerics, katakana, symbols, spaces). Supports multiple and rectangular selections.

### Links

- Source & README: https://github.com/RivieraSystems/NppZenHankaku
- Release (v1.0.0): https://github.com/RivieraSystems/NppZenHankaku/releases/tag/v1.0.0
- Download ZIP: https://github.com/RivieraSystems/NppZenHankaku/releases/download/v1.0.0/NppZenHankaku_1.0.0_x64.zip

### Entry details

- `folder-name`: `NppZenHankaku`
- `display-name`: `NppZenHankaku`
- `version`: `1.0.0`
- Architecture: x64 only (`pl.x64.json`)
- ZIP layout: `NppZenHankaku.dll` at the root of the ZIP
- DLL file version: `1.0.0.0`
- SHA-256 (`id`): `f1dfe323bd9b17075138274e7ed2a6848d588a29e57da866186e3102c36f24d2`

### Checklist

- [x] Entry added to `pl.x64.json`, alphabetically by `folder-name` (after `NppXmlTreeviewPlugin`)
- [ ] JSON loaded using the Notepad++ debug build
- [ ] Plugin appears correctly in Plugins Admin
- [x] ZIP contains `NppZenHankaku.dll` at its root
- [x] DLL name matches `folder-name`
- [x] `id` is the SHA-256 of the exact release ZIP
- [x] `repository` URL downloads the ZIP directly
- [x] DLL contains version information matching `1.0.0`
- [x] Source repository is public and contains a README
