### PR TITLE
Update Graph Builder to 1.3.7

### DIFF
--- a/src/pl.x64.json
+++ b/src/pl.x64.json
@@ -654,9 +654,9 @@
 		{
 			"folder-name": "GraphBuilderLaz",
 			"display-name": "Graph Builder",
-			"version": "1.3.6",
-			"id": "e4328d36f02fc3d3981cc2d3c12a7c192613e01b15bf9c0bf59f0134bc5b9aab",
-			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.3.6/GraphBuilder-npp-1.3.6-win64.zip",
+			"version": "1.3.7",
+			"id": "54b62040c4b562180adfb4a67033be8502f6bf6a86ad5ba1e9173a0a9ae8d058",
+			"repository": "https://github.com/pisarev/graphbuilder-npp/releases/download/v1.3.7/GraphBuilder-npp-1.3.7-win64.zip",
 			"description": "[Requires the WebView2 runtime, which ships with Windows 11 and arrives with Edge on Windows 10]\r\nA docked panel that plots the formula under your mouse: roots, intersections, extrema, a report, and a formula fitted to pasted data.",
 			"author": "Yuriy Pisarev",
 			"homepage": "https://github.com/pisarev/graphbuilder-npp"


### PR DESCRIPTION
Updates Graph Builder from 1.3.6 to 1.3.7.

- version: 1.3.6 -> 1.3.7
- repository: the v1.3.7 release asset
- id: sha256 of GraphBuilder-npp-1.3.7-win64.zip

The archive holds the same five members as the 1.3.6 entry, with GraphBuilderLaz.dll at its root.
